### PR TITLE
Use ngsecurity in gallery

### DIFF
--- a/angular_gallery/pubspec.yaml
+++ b/angular_gallery/pubspec.yaml
@@ -11,6 +11,8 @@ dependencies:
   build: ^2.1.1
   build_config: ^1.0.0
   mustache: ^1.0.0
+  ngsecurity:
+    git: git@github.com:angulardart-community/ngsecurity.git
 
 dependency_overrides:
   angular_components:

--- a/angular_gallery_section/lib/components/gallery_component/documentation_component.dart
+++ b/angular_gallery_section/lib/components/gallery_component/documentation_component.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:angular/angular.dart';
-import 'package:angular/security.dart';
+import 'package:ngsecurity/security.dart';
 import 'package:angular_gallery_section/components/gallery_component/gallery_info.dart';
 
 /// A list of all documentation directives.


### PR DESCRIPTION
Actually no usage in `package:angular_components` but just in gallery

Note that we will need to publish ngsecurity later

Fix #2 