### PR TITLE
Remove latency chart and benchmarks config

### DIFF
--- a/angular_gallery_section/lib/annotation/gallery_section_config.dart
+++ b/angular_gallery_section/lib/annotation/gallery_section_config.dart
@@ -32,11 +32,6 @@ class GallerySectionConfig {
   /// be added in the demos section.
   final Type mainDemo;
 
-  /// The embed URLs for benchmark charts to display in this section.
-  ///
-  /// The charts are displayed in the order they are specified here.
-  final List<String> benchmarks;
-
   /// A list of owners for the components in this section.
   final List<String> owners;
 
@@ -56,7 +51,6 @@ class GallerySectionConfig {
       this.docs,
       this.demos,
       this.mainDemo,
-      this.benchmarks,
       this.owners,
       this.uxOwners,
       this.relatedUrls,

--- a/angular_gallery_section/lib/builder/component_api_builder.dart
+++ b/angular_gallery_section/lib/builder/component_api_builder.dart
@@ -79,7 +79,6 @@ class ComponentApiBuilder extends Builder {
               return jsonMap;
             })?.toList() ??
             [],
-        'benchmarks': config.benchmarks ?? [],
         'owners': config.owners,
         'uxOwners': config.uxOwners,
         'relatedUrls': config.relatedUrls?.entries

--- a/angular_gallery_section/lib/builder/gallery_info_builder.dart
+++ b/angular_gallery_section/lib/builder/gallery_info_builder.dart
@@ -59,7 +59,6 @@ class GalleryInfoBuilder extends Builder {
         final resolved = ResolvedConfig()
           ..displayName = config.displayName
           ..group = config.group
-          ..benchmarks = config.benchmarks
           ..owners = config.owners
           ..uxOwners = config.uxOwners
           ..relatedUrls = config.relatedUrls

--- a/angular_gallery_section/lib/builder/template/component.api.dart.mustache
+++ b/angular_gallery_section/lib/builder/template/component.api.dart.mustache
@@ -114,11 +114,6 @@ class {{component}}Api {
       mainDemo:
           Demo({{mainDemo.className}}NgFactory, '{{mainDemo.className}}','{{mainDemo.examplePath}}'),
       {{/hasMainDemo}}
-      benchmarks: [
-        {{#benchmarks}}
-          '{{.}}',
-        {{/benchmarks}}
-      ],
       relatedUrls: {
         {{#relatedUrls}}
           '{{key}}': '{{value}}',

--- a/angular_gallery_section/lib/components/gallery_component/gallery_component.dart
+++ b/angular_gallery_section/lib/components/gallery_component/gallery_component.dart
@@ -40,15 +40,9 @@ class GalleryComponent {
   /// The beginning of the link to the source code for all components.
   final String _sourcecodeUrl;
 
-  /// Used to disable latency charts in testing environments where they can't
-  /// load successfully.
-  final latencyChartsEnabled =
-      !window.location.href.contains('enableLatencyCharts=false');
-
   GalleryComponent(@sourcecodeUrl this._sourcecodeUrl);
 
-  bool get showToc =>
-      (model.docs.length + model.demos.length + model.benchmarks.length) > 1;
+  bool get showToc => (model.docs.length + model.demos.length) > 1;
 
   String getDocId(DocInfo doc) => '${doc.name.replaceAll(' ', '_')}Doc';
 

--- a/angular_gallery_section/lib/components/gallery_component/gallery_component.html
+++ b/angular_gallery_section/lib/components/gallery_component/gallery_component.html
@@ -53,11 +53,6 @@
       {{demo.name}}
     </a>
   </ng-container>
-
-  <ng-container *ngIf="latencyChartsEnabled && model.benchmarks.isNotEmpty">
-    <label>Latency</label>
-    <a buttonDecorator (trigger)="scroll('#latency')">Latency Charts</a>
-  </ng-container>
 </section>
 
 <section *ngFor="let doc of model.docs" class="doc">
@@ -88,10 +83,4 @@
     <a [href]="getCodeSearchLink(demo.path)" target="_blank">Source Code</a>
   </h2>
   <dynamic-component [componentFactory]="demo.demoFactory"></dynamic-component>
-</section>
-
-<section *ngIf="latencyChartsEnabled && model.benchmarks.isNotEmpty" class="latency-chart">
-  <h2 id="latency">Latency Charts</h2>
-  <latency-chart *ngFor="let url of model.benchmarks">
-  </latency-chart>
 </section>

--- a/angular_gallery_section/lib/components/gallery_component/gallery_info.dart
+++ b/angular_gallery_section/lib/components/gallery_component/gallery_info.dart
@@ -22,11 +22,6 @@ class GalleryInfo {
   // Component example to include at the top of the gallery section.
   final Demo mainDemo;
 
-  /// The embed URLs for benchmark charts to display in this section.
-  ///
-  /// The charts are displayed in the order they are specified here.
-  final List<String> benchmarks;
-
   /// A list of owners for the components in this section.
   final List<String> owners;
 
@@ -44,7 +39,6 @@ class GalleryInfo {
       {this.docs = const [],
       this.demos = const [],
       this.mainDemo,
-      this.benchmarks = const [],
       this.owners = const [],
       this.uxOwners = const [],
       this.relatedUrls = const {},

--- a/angular_gallery_section/lib/gallery_section_config_extraction.dart
+++ b/angular_gallery_section/lib/gallery_section_config_extraction.dart
@@ -70,8 +70,6 @@ class _GallerySectionConfigVisitor extends SimpleAstVisitor<ConfigInfo> {
       config.demoClassNames = expression.accept(ListStringExtractor());
     } else if (name == 'mainDemo') {
       config.mainDemoName = expression.accept(StringExtractor());
-    } else if (name == 'benchmarks') {
-      config.benchmarks = expression.accept(ListStringExtractor());
     } else if (name == 'owners') {
       config.owners = expression.accept(ListStringExtractor());
     } else if (name == 'uxOwners') {
@@ -93,7 +91,6 @@ class ConfigInfo {
   Iterable<String> docs;
   Iterable<String> demoClassNames;
   String mainDemoName;
-  Iterable<String> benchmarks;
   Iterable<String> owners;
   Iterable<String> uxOwners;
   Map<String, String> relatedUrls;

--- a/angular_gallery_section/lib/resolved_config.dart
+++ b/angular_gallery_section/lib/resolved_config.dart
@@ -16,7 +16,6 @@ class ResolvedConfig {
   Iterable<DocInfo> docs;
   Iterable<DemoInfo> demos;
   DemoInfo mainDemo;
-  Iterable<String> benchmarks;
   Iterable<String> owners;
   Iterable<String> uxOwners;
   Map<String, String> relatedUrls;
@@ -56,7 +55,6 @@ class ResolvedConfig {
     if (jsonMap['mainDemo'] != null) {
       mainDemo = DemoInfo.fromJson(jsonMap['mainDemo']);
     }
-    benchmarks = (jsonMap['benchmarks'] as Iterable)?.cast<String>();
     owners = (jsonMap['owners'] as Iterable)?.cast<String>();
     uxOwners = (jsonMap['uxOwners'] as Iterable)?.cast<String>();
     relatedUrls = (jsonMap['relatedUrls'] as Map)?.cast<String, String>();
@@ -70,7 +68,6 @@ class ResolvedConfig {
         'docs': docs?.toList(),
         'demos': demos?.toList(),
         'mainDemo': mainDemo,
-        'benchmarks': benchmarks?.toList(),
         'owners': owners?.toList(),
         'uxOwners': uxOwners?.toList(),
         'relatedUrls': relatedUrls,


### PR DESCRIPTION
latency-chart is not in source code

and probably not used on the gallery anymore

https://angulardart.github.io/angular_components/#/material_button?enableLatencyCharts=true