### PR TITLE
Fix mono repo pub get

### DIFF
--- a/examples/material_menu_example/pubspec.yaml
+++ b/examples/material_menu_example/pubspec.yaml
@@ -12,7 +12,6 @@ dependencies:
   angular_gallery_section:
     path: ../../angular_gallery_section
   build_config: ^1.0.0
-  observable: ^0.23.0
 
 dependency_overrides:
   angular_components:


### PR DESCRIPTION
`mono_repo pub get` was failing due to bad dependencies on material_menu_example