### PR TITLE
Remove ngsecurity

### DIFF
--- a/angular_gallery/pubspec.yaml
+++ b/angular_gallery/pubspec.yaml
@@ -11,8 +11,6 @@ dependencies:
   build: ^2.1.1
   build_config: ^1.0.0
   mustache: ^1.0.0
-  ngsecurity:
-    git: https://github.com/angulardart-community/ngsecurity
 
 dependency_overrides:
   angular_components:

--- a/angular_gallery_section/lib/components/gallery_component/dart_doc_component.html
+++ b/angular_gallery_section/lib/components/gallery_component/dart_doc_component.html
@@ -17,7 +17,7 @@
   <code>{{doc.exportAs}}</code>
 </p>
 
-<div [safeInnerHtml]="getSafeHtml(doc.comment)"></div>
+<div [innerHtml]="doc.comment"></div>
 
 <ng-container *ngIf="showGeneratedDocs">
   <div *ngIf="doc.inputs.isNotEmpty">
@@ -35,7 +35,7 @@
         <p *ngIf="input.comment.isEmpty && !input.deprecated">
           Missing a Dart Doc comment.
         </p>
-        <div [safeInnerHtml]="getSafeHtml(input.comment)"></div>
+        <div [innerHtml]="input.comment"></div>
       </li>
     </ul>
   </div>
@@ -54,7 +54,7 @@
         <p *ngIf="output.comment.isEmpty && !output.deprecated">
           Missing a Dart Doc comment.
         </p>
-        <div [safeInnerHtml]="getSafeHtml(output.comment)"></div>
+        <div [innerHtml]="output.comment"></div>
       </li>
     </ul>
   </div>

--- a/angular_gallery_section/lib/components/gallery_component/documentation_component.dart
+++ b/angular_gallery_section/lib/components/gallery_component/documentation_component.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:angular/angular.dart';
-import 'package:ngsecurity/security.dart';
 import 'package:angular_gallery_section/components/gallery_component/gallery_info.dart';
 
 /// A list of all documentation directives.
@@ -16,21 +15,6 @@ const documentationComponentDirectives = [
 class DocumentationComponent {
   @Input()
   bool showGeneratedDocs;
-
-  final _sanitizedHtml = <String, SafeHtml>{};
-
-  DomSanitizationService _santizationService;
-
-  DocumentationComponent(this._santizationService);
-
-  SafeHtml getSafeHtml(String value) {
-    var html = _sanitizedHtml[value];
-    if (html == null) {
-      html = _santizationService.bypassSecurityTrustHtml(value);
-      _sanitizedHtml[value] = html;
-    }
-    return html;
-  }
 }
 
 /// Displays documentation for dart files in the gallery application.
@@ -41,15 +25,11 @@ class DocumentationComponent {
   directives: [
     NgFor,
     NgIf,
-    SafeInnerHtmlDirective,
   ],
   templateUrl: 'dart_doc_component.html',
   styleUrls: ['documentation_component.scss.css'],
 )
 class DartDocComponent extends DocumentationComponent {
-  DartDocComponent(DomSanitizationService santizationService)
-      : super(santizationService);
-
   /// The documentation to display.
   @Input()
   DartDocInfo doc;
@@ -60,14 +40,10 @@ class DartDocComponent extends DocumentationComponent {
 /// Typically used for the generated HTML from a markdown README.
 @Component(
   selector: 'documentation-component[markdown]',
-  directives: [SafeInnerHtmlDirective],
-  template: '<div [safeInnerHtml]="getSafeHtml(doc.contents)"></div>',
+  template: '<div [innerHtml]="doc.contents"></div>',
   styleUrls: ['documentation_component.scss.css'],
 )
 class MarkdownDocComponent extends DocumentationComponent {
-  MarkdownDocComponent(DomSanitizationService santizationService)
-      : super(santizationService);
-
   /// The documentation to display.
   @Input()
   MarkdownDocInfo doc;
@@ -82,15 +58,11 @@ class MarkdownDocComponent extends DocumentationComponent {
   directives: [
     NgFor,
     NgIf,
-    SafeInnerHtmlDirective,
   ],
   templateUrl: 'sass_doc_component.html',
   styleUrls: ['documentation_component.scss.css'],
 )
 class SassDocComponent extends DocumentationComponent {
-  SassDocComponent(DomSanitizationService santizationService)
-      : super(santizationService);
-
   /// The documentation to display.
   @Input()
   SassDocInfo doc;

--- a/angular_gallery_section/lib/components/gallery_component/sass_doc_component.html
+++ b/angular_gallery_section/lib/components/gallery_component/sass_doc_component.html
@@ -5,7 +5,7 @@
 -->
 <div
     *ngIf="doc.libraryDoc.isNotEmpty"
-    [safeInnerHtml]="getSafeHtml(doc.libraryDoc)">
+    [innerHtml]="doc.libraryDoc">
 </div>
 
 <ng-container *ngIf="doc.variables.isNotEmpty">
@@ -13,7 +13,7 @@
   <ul class="property-list">
     <li *ngFor="let variable of doc.variables">
       <code class="property-name">${{variable.name}}</code>
-      <div *ngIf="variable.comment.isNotEmpty" [safeInnerHtml]="getSafeHtml(variable.comment)">
+      <div *ngIf="variable.comment.isNotEmpty" [innerHtml]="variable.comment">
       </div>
     </li>
   </ul>
@@ -24,7 +24,7 @@
   <ul class="property-list">
     <li *ngFor="let function of doc.functions">
       <code class="property-name">{{function.signature}}</code>
-      <div *ngIf="function.comment.isNotEmpty" [safeInnerHtml]="getSafeHtml(function.comment)">
+      <div *ngIf="function.comment.isNotEmpty" [innerHtml]="function.comment">
       </div>
     </li>
   </ul>
@@ -35,7 +35,7 @@
   <ul class="property-list">
     <li *ngFor="let mix of doc.mixins">
       <code class="property-name">{{mix.signature}}</code>
-      <div *ngIf="mix.comment.isNotEmpty" [safeInnerHtml]="getSafeHtml(mix.comment)"></div>
+      <div *ngIf="mix.comment.isNotEmpty" [innerHtml]="mix.comment"></div>
     </li>
   </ul>
 </ng-container>

--- a/angular_gallery_section/pubspec.yaml
+++ b/angular_gallery_section/pubspec.yaml
@@ -18,9 +18,6 @@ dependencies:
   path: ^1.6.1
   sass: '>=1.15.3 <2.0.0'
 
-  ngsecurity: 
-    git: https://github.com/angulardart-community/ngsecurity
-
 dependency_overrides:
   angular_components:
     path: ../angular_components


### PR DESCRIPTION
Dom Sanitization seems to be handle by compiler now so we don't need ngsecurity package anymore

```
/// The top-level methods are intended to be used only by code generated by the
/// compiler when it "sees" that a potential unsafe operation would otherwise be
/// used (i.e. `<div [innerHtml]="someValue"></div>`).
```

https://github.com/angulardart/angular/blob/master/angular/lib/src/security/safe_html_adapter.dart