### PR TITLE
removed deprecated detectChanges call in input multiline

### DIFF
--- a/angular_components/lib/material_input/material_input_multiline.dart
+++ b/angular_components/lib/material_input/material_input_multiline.dart
@@ -117,10 +117,7 @@ class MaterialMultilineInputComponent extends BaseMaterialInput
         _inputLineHeight = height;
         _subscription?.cancel();
         _subscription = null;
-        _changeDetector
-          ..markForCheck()
-          // TODO(google): remove after the bug is fixed.
-          ..detectChanges();
+        _changeDetector.markForCheck();
       } else if (_subscription == null) {
         // Listen to dom changes until we can read the line height.
         _subscription = _domService.onLayoutChanged.listen((_) {


### PR DESCRIPTION
I've tested it and it didn't change any of the original behavior. So I think it is safe for us to remove the detectChanges call.