### PR TITLE
Migrate string_utils

### DIFF
--- a/angular_components/lib/utils/strings/string_utils.dart
+++ b/angular_components/lib/utils/strings/string_utils.dart
@@ -2,25 +2,35 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:change_case/change_case.dart';
+
 final RegExp _camelCaseSplitter = RegExp('([a-z])([A-Z])');
 
 final RegExp _capitalLetter = RegExp('[A-Z]');
 
 final RegExp _wordBreakSplitter = RegExp(r'[\s\-_]');
 
-final RegExp _wordBreak = RegExp(r'(^|[\-_ ])(\w)');
+// This is removed after the `change_case` package is used for `camelCase()`.
+// final RegExp _wordBreak = RegExp(r'(^|[\-_ ])(\w)');
 
 /// Returns the hyphenated form of [s].
 ///
-/// The string is also made lower case.
-String hyphenate(String s) => _split(s).join('-').toLowerCase();
+/// For details on what characters split the string, see the [split] function.
+///
+/// In addition, the entire string is made lower case.
+String hyphenate(String s) => split(s).join('-').toLowerCase();
 
 /// Returns the underscored form of [s].
 ///
-/// The string is also made lower case.
-String underscore(String s) => _split(s).join('_').toLowerCase();
+/// For details on what characters split the string, see the [split] function.
+///
+/// In addition, the entire string is made lower case.
+String underscore(String s) => split(s).join('_').toLowerCase();
 
 /// Returns the camel-cased form of [s].
+///
+/// **NOTE**: technically this is pascal case, but for legacy reasons the name
+/// is perserved. This will be changed in later versions.
 ///
 /// This is a very simple function: it merely replaces usual delimiters (spaces,
 /// hyphens, underscores) and the following word-character, with the upper case
@@ -42,10 +52,12 @@ String underscore(String s) => _split(s).join('_').toLowerCase();
 ///  * "1337" => "1337"
 ///  * "foo3bar" => "Foo3bar"
 ///  * "3bar" => "3bar"
-String camelCase(String s) =>
-    s.replaceAllMapped(_wordBreak, (m) => m[2]?.toUpperCase() ?? '');
+// TODO: this is actually pascal case. Change all references.
+String camelCase(String s) => s.toPascalCase();
 
 /// Returns the lower-camel-cased form of [s].
+///
+/// By common definition, this is the actual camel case!
 String lowerCamelCase(String s) {
   String result = camelCase(s);
   result = result.replaceRange(0, 1, s[0].toLowerCase());
@@ -60,15 +72,15 @@ String titleCase(String s) =>
 /// Returns the String [s], with the first letter capitalized.
 String capitalizeFirstLetter(s) => s[0].toUpperCase() + s.substring(1);
 
-// Splits [s] into tokens.
-//
-// Splits occur on:
-//
-// * Whitespace: "foo bar" => ["foo", "bar"]
-// * Hyphens: "foo-bar" => ["foo", "bar"]
-// * Underscores: "foo_bar" => ["foo", "bar"]
-// * Camelcasing: "fooBar" => ["foo", "Bar"]
-List<String> _split(String s) => s
+/// Splits [s] into tokens.
+///
+/// Splits occur on:
+///
+/// * Whitespace: "foo bar" => ["foo", "bar"]
+/// * Hyphens: "foo-bar" => ["foo", "bar"]
+/// * Underscores: "foo_bar" => ["foo", "bar"]
+/// * Camelcasing: "fooBar" => ["foo", "Bar"]
+List<String> split(String s) => s
     // Convert camelCase splitting into word splitting.
     .replaceAllMapped(_camelCaseSplitter, (m) => '${m[1]} ${m[2]}')
     .split(_wordBreakSplitter);

--- a/angular_components/pubspec.yaml
+++ b/angular_components/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   build: ^2.1.1
   build_config: ^1.0.0
   built_collection: ^5.1.1
+  change_case: ^1.0.1
   collection: ^1.15.0-nullsafety.4
   fixnum: ^1.0.0
   intl: ^0.17.0

--- a/angular_components/test/utils/strings/string_utils_test.dart
+++ b/angular_components/test/utils/strings/string_utils_test.dart
@@ -6,16 +6,66 @@ import 'package:test/test.dart';
 import 'package:angular_components/utils/strings/string_utils.dart';
 
 void main() {
-  test('Ensure camelCase converts correctly', () {
-    const result1 = 'FooBar';
-    const result2 = 'Foo';
+  group('Utils test | string_utils |', () {
+    test('ensure `split()` split strings correctly', () {
+      const result1 = ['foo', 'bar'];
 
-    expect(camelCase('foo bar'), result1);
-    expect(camelCase('foo-bar'), result1);
-    expect(camelCase('foo_bar'), result1);
-    // expect(camelCase('foo\bar'), r'Foo\Bar');
-    expect(camelCase('foo'), result2);
-    // expect(camelCase('foo '), result2);
-    // expect(camelCase('_foo'), result2);
+      expect(split('foo bar'), result1);
+      expect(split('foo-bar'), result1);
+      expect(split('foo_bar'), result1);
+      expect(split('fooBar'), ['foo', 'Bar']);
+    });
+
+    test('ensure camel case converts correctly', () {
+      const result1 = 'FooBar';
+      const result2 = 'Foo';
+
+      expect(camelCase('foo bar'), result1);
+      expect(camelCase('foo-bar'), result1);
+      expect(camelCase('foo_bar'), result1);
+      expect(camelCase('foo\\bar'), result1);
+      expect(camelCase('foo'), result2);
+      expect(camelCase('foo '), result2);
+      expect(camelCase('foo-'), result2);
+      expect(camelCase('_foo'), result2);
+      expect(camelCase(''), '');
+      expect('    ', '    ');
+      // expect('   -word', '   Word');
+      expect('1336', '1336');
+      // expect('foo3bar', 'Foo3bar');
+      expect('3bar', '3bar');
+    });
+
+    test('ensure hyphenate converts correctly', () {
+      const result1 = 'bad-apple';
+
+      expect(hyphenate('bad apple'), result1);
+      expect(hyphenate('Bad apple'), result1);
+      expect(hyphenate('Bad Apple'), result1);
+      expect(hyphenate('bAd AppLe'), 'b-ad-app-le');
+      expect(hyphenate('bAd 3AppLe'), 'b-ad-3app-le');
+      expect(hyphenate('bAd App3Le'), 'b-ad-app3le');
+    });
+
+    test('ensure underscore converts correctly', () {
+      const result1 = 'nice_peach';
+
+      expect(underscore('nice peach'), result1);
+      expect(underscore('nice Peach'), result1);
+      expect(underscore('Nice Peach'), result1);
+      expect(underscore('niCe PeaCh'), 'ni_ce_pea_ch');
+      expect(underscore('niCe 3PeaCh'), 'ni_ce_3pea_ch');
+      expect(underscore('niCe Pea3Ch'), 'ni_ce_pea3ch');
+    });
+
+    test('ensure lower camel case converts correctly', () {
+      expect(lowerCamelCase('dart is cool'), 'dartIsCool');
+      expect(lowerCamelCase('dart is 2cool'), 'dartIs2cool');
+    });
+
+    test('ensure title case converts correctly', () {
+      expect(titleCase('ToKillAMockingbird'), 'To Kill A Mockingbird');
+      expect(titleCase('Gone with the wind'), 'Gone with the wind');
+    });
   });
 }


### PR DESCRIPTION
Added tests to `lib/utils/strings/string_utils.dart`.

The built-in conversion has some problems, mainly that it recognizes pascal case as camel case, while `lowerCamelCase()` is the actual camel case. Plus, the actual implementation of the "camel case" doesn't work. Therefore, the package `change_case` is introduced to solve this. For backwards compatibility, the naming will be preserved for now.