### PR TITLE
Fix package analysis detecting web-incompatible

### DIFF
--- a/angular_components/build.yaml
+++ b/angular_components/build.yaml
@@ -1,14 +1,14 @@
 targets:
   angular_components:
     sources:
-      exclude: ["lib/builder.dart"]
+      exclude: ["lib/src/builder.dart"]
     builders:
       sass_builder|sass_builder:
         enabled: False
       angular_components|scss_builder:
         enabled: True
   scss_builder:
-    sources: ["lib/builder.dart"]
+    sources: ["lib/src/builder.dart"]
     dependencies:
       - build
       - sass_builder
@@ -17,7 +17,7 @@ targets:
 builders:
   scss_builder:
     target: "scss_builder"
-    import: "package:angular_components/builder.dart"
+    import: "package:angular_components/src/builder.dart"
     builder_factories: ["scssBuilder"]
     build_to: cache
     build_extensions:

--- a/angular_components/lib/src/builder.dart
+++ b/angular_components/lib/src/builder.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart=2.9
-
 import 'package:build/build.dart';
 import 'package:sass_builder/sass_builder.dart';
 


### PR DESCRIPTION
The Dart Package ANAlysis system can't recognize this package as js-compatible because of the file `lib/builder.dart` that uses `dart:io`. By moving the file to `lib/src/builder.dart` and stop exporting it, this should stop PANA from detecting it and hence reporting our package as web-compatible.