### PR TITLE
Fixed material radio

### DIFF
--- a/angular_components/lib/laminate/components/modal/modal.dart
+++ b/angular_components/lib/laminate/components/modal/modal.dart
@@ -308,10 +308,19 @@ class ModalComponent
       controller.execute(_showModalOverlay);
       _pendingOpen = controller.action!.onDone.then((completed) {
         _pendingOpen = null;
-        return completed;
+
+        if (completed == null) {
+          return false;
+        }
+
+        if (completed is bool) {
+          return completed;
+        }
+        return false;
       });
       _onOpen.add(controller.action);
     }
+
     return _pendingOpen;
   }
 

--- a/angular_components/lib/material_menu/menu_item_groups.dart
+++ b/angular_components/lib/material_menu/menu_item_groups.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 import 'dart:html';
 
 import 'package:angular/angular.dart';
-import 'package:angular/src/meta.dart';
 import 'package:angular_components/button_decorator/button_decorator.dart';
 import 'package:angular_components/content/deferred_content.dart';
 import 'package:angular_components/focus/focus.dart';
@@ -589,7 +588,7 @@ class MenuItemGroupsComponent
 
           if (!item.hasSubMenu) {
             item.ariaChecked = isSelected.toString();
-          } else if (group.selectionModel.isSingleSelect!) {
+          } else if (group.selectionModel.isSingleSelect) {
             item.ariaChecked =
                 (isSelected || _anyChildrenSelected(group, item)).toString();
           } else {

--- a/angular_components/lib/material_radio/material_radio.dart
+++ b/angular_components/lib/material_radio/material_radio.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 import 'dart:html';
 
 import 'package:angular/angular.dart';
-import 'package:angular/src/meta.dart';
 import 'package:angular_components/focus/focus.dart';
 import 'package:angular_components/interfaces/has_disabled.dart';
 import 'package:angular_components/material_icon/material_icon.dart';
@@ -116,9 +115,9 @@ class MaterialRadioComponent extends RootFocusable
 
     if (_group != null) {
       if (isChecked) {
-        _group?.componentSelection.select(this);
+        _group!.componentSelection.select(this);
       } else {
-        _group?.componentSelection.deselect(this);
+        _group!.componentSelection.deselect(this);
       }
     }
     _onChecked.add(_checked);
@@ -133,7 +132,7 @@ class MaterialRadioComponent extends RootFocusable
 
   /// Current icon, depends on the state of [checked].
   @visibleForTemplate
-  Icon get icon => _checked ? checkedIcon : uncheckedIcon;
+  Icon get icon => checked ? checkedIcon : uncheckedIcon;
 
   /// Current tab index, depends on state of [disabled] and selection status
   /// if in group.

--- a/angular_components/lib/material_radio/material_radio_group.dart
+++ b/angular_components/lib/material_radio/material_radio_group.dart
@@ -10,6 +10,7 @@ import 'package:angular_components/focus/focus.dart';
 import 'package:angular_components/material_radio/material_radio.dart';
 import 'package:angular_components/model/selection/selection_model.dart';
 import 'package:angular_components/utils/disposer/disposer.dart';
+import 'package:collection/collection.dart';
 
 /// Group containing multiple material radio buttons, enforcing that only one
 /// value in the group is selected.
@@ -42,7 +43,7 @@ class MaterialRadioGroupComponent
   final NgZone _ngZone;
   final _disposer = Disposer.oneShot();
 
-  List<MaterialRadioComponent> _radioComponents = <MaterialRadioComponent>[];
+  List<MaterialRadioComponent> _radioComponents = [];
 
   MaterialRadioGroupComponent(this._ngZone, @Self() @Optional() NgControl? cd) {
     // When NgControl is present on the host element, the component participates
@@ -62,7 +63,7 @@ class MaterialRadioGroupComponent
       _resetTabIndex();
       _selected = _selectedRadioComponent?.value;
       if (_valueSelection != null && _selected != null) {
-        _valueSelection!.select(_selected);
+        _valueSelection?.select(_selected);
       }
       _onChange.add(_selected);
     }));
@@ -110,8 +111,8 @@ class MaterialRadioGroupComponent
     // Since this is updating children that were already dirty-checked,
     // need to delay this change until next angular cycle.
     _ngZone.runAfterChangesObserved(() {
-      //if (_radioComponents == null) return; // Component was destroyed.
-      if (_radioComponents.isEmpty) return; // Component was destroyed.
+      //if (_radioComponents.isEmpty) return; // Component was destroyed.
+
       // Disable everything first.
       for (var radioComponent in _radioComponents) {
         radioComponent.tabbable = false;
@@ -138,6 +139,7 @@ class MaterialRadioGroupComponent
   /// Published when selection changes. Prefer `(ngModelChange)`.
   @Output('selectedChange')
   Stream<dynamic> get onChange => _onChange.stream;
+
   final _onChange = StreamController<dynamic>.broadcast();
 
   /// Selection model containing value object.
@@ -147,8 +149,7 @@ class MaterialRadioGroupComponent
     _selectionSubscription?.cancel();
     _valueSelection = value;
     _selectionSubscription = _valueSelection?.selectionChanges.listen((_) {
-      selected = _valueSelection!.selectedValues
-          .firstWhere((_) => true, orElse: () => null);
+      selected = _valueSelection?.selectedValues.firstWhereOrNull((_) => true);
     });
   }
 
@@ -171,6 +172,8 @@ class MaterialRadioGroupComponent
   dynamic _preselectedValue;
   bool _isContentInit = false;
 
+  dynamic _selected;
+
   /// Value of currently selected radio. Prefer `[ngModel]`.
   @Input()
   set selected(dynamic selectedValue) {
@@ -185,7 +188,6 @@ class MaterialRadioGroupComponent
     }
   }
 
-  dynamic _selected;
   dynamic get selected => _selected;
 
   void _moveFocus(FocusMoveEvent event) => _move(event);

--- a/angular_components/lib/model/menu/selectable_menu.dart
+++ b/angular_components/lib/model/menu/selectable_menu.dart
@@ -42,7 +42,7 @@ class MenuItemGroupWithSelection<SelectionItemType>
       bool? shouldCloseMenuOnSelection})
       : shouldCloseMenuOnSelection = shouldCloseMenuOnSelection ??
             selectionModel is! MultiSelectionModel,
-        itemsRole = (selectionModel.isSingleSelect ?? true)
+        itemsRole = (selectionModel.isSingleSelect)
             ? 'menuitemradio'
             : 'menuitemcheckbox',
         super(items, label);

--- a/angular_components/lib/model/selection/selection_model.dart
+++ b/angular_components/lib/model/selection/selection_model.dart
@@ -46,7 +46,7 @@ abstract class SelectionModel<T> extends Object
   const factory SelectionModel.empty() = NullSelectionModel<T>;
 
   /// Whether or not the selection model is single select.
-  bool? get isSingleSelect;
+  bool get isSingleSelect;
 
   /// Creates a single-selection model.
   ///
@@ -69,6 +69,7 @@ abstract class SelectionModel<T> extends Object
       {List<T> selectedValues,
       KeyProvider<T>? keyProvider}) = MultiSelectionModel<T>;
 
+  /*
   @Deprecated('Use SelectionModel.single or SelectionModel.multi instead.')
   factory SelectionModel.withList(
       {List<T> selectedValues = const [],
@@ -83,6 +84,7 @@ abstract class SelectionModel<T> extends Object
           keyProvider: keyProvider);
     }
   }
+  */
 
   /// Clears selection.
   void clear();

--- a/angular_components/lib/model/selection/tree_propagation_selection_model.dart
+++ b/angular_components/lib/model/selection/tree_propagation_selection_model.dart
@@ -34,6 +34,9 @@ class TreePropagationSelectionModel<T>
     return wasNewSelection;
   }
 
+  @override
+  bool get isSingleSelect => true;
+
   /// When given a un-selected entity, this will check the
   /// treeoptions for children and deselect them.
   @override

--- a/angular_components/lib/src/model/selection/delegating_selection_model.dart
+++ b/angular_components/lib/src/model/selection/delegating_selection_model.dart
@@ -14,7 +14,7 @@ class DelegatingSelectionModel<T> extends Object
   final SelectionModel<T> _delegateModel;
 
   @override
-  final bool? isSingleSelect;
+  bool isSingleSelect;
 
   DelegatingSelectionModel(this._delegateModel)
       : isSingleSelect = _delegateModel.isSingleSelect;

--- a/angular_components/lib/src/model/selection/multi_selection_model_impl.dart
+++ b/angular_components/lib/src/model/selection/multi_selection_model_impl.dart
@@ -4,7 +4,7 @@
 
 part of angular_components.model.selection.selection_model;
 
-class _MultiSelectionModelImpl<T> extends Observable<ChangeRecord>
+class _MultiSelectionModelImpl<T> extends PropertyChangeNotifier
     with SelectionChangeNotifier<T>, CastIterable<T>
     implements MultiSelectionModel<T> {
   @override
@@ -66,7 +66,7 @@ class _MultiSelectionModelImpl<T> extends Observable<ChangeRecord>
   }
 
   @override
-  void selectAll(Iterable<T> values) {
+  void selectAll(Iterable<T>? values) {
     if (values == null) {
       throw ArgumentError();
     }
@@ -82,7 +82,7 @@ class _MultiSelectionModelImpl<T> extends Observable<ChangeRecord>
   }
 
   @override
-  void deselectAll(Iterable<T> values) {
+  void deselectAll(Iterable<T>? values) {
     if (values == null) {
       throw ArgumentError();
     }

--- a/angular_components/lib/src/model/selection/noop_selection_model_impl.dart
+++ b/angular_components/lib/src/model/selection/noop_selection_model_impl.dart
@@ -9,7 +9,7 @@ class _NoopSelectionModelImpl<T> implements NullSelectionModel<T> {
   const _NoopSelectionModelImpl();
 
   @override
-  final bool? isSingleSelect = null;
+  final bool isSingleSelect = true;
 
   // Selection observable.
 

--- a/angular_components/lib/src/model/selection/radio_group_single_selection_model.dart
+++ b/angular_components/lib/src/model/selection/radio_group_single_selection_model.dart
@@ -8,8 +8,7 @@ import 'package:angular_components/model/selection/selection_model.dart';
 class RadioGroupSingleSelectionModel<T>
     extends DelegatingSingleSelectionModel<T> {
   RadioGroupSingleSelectionModel([T? initialValue])
-      : super(SelectionModel<T>.single(
-                selected: initialValue == null ? null : initialValue)
+      : super(SelectionModel<T>.single(selected: initialValue)
             as SingleSelectionModel<T>);
   //as SingleSelectionModel<T*>);
 
@@ -17,5 +16,5 @@ class RadioGroupSingleSelectionModel<T>
   void clear() {}
 
   @override
-  bool deselect(T? value) => false;
+  bool deselect(T value) => false;
 }

--- a/angular_components/lib/src/model/selection/selection_change_notifier.dart
+++ b/angular_components/lib/src/model/selection/selection_change_notifier.dart
@@ -24,15 +24,18 @@ abstract class SelectionObservable<T> {
 /// Mixin for providing [SelectionModel.selectionChanges].
 abstract class SelectionChangeNotifier<T> implements SelectionModel<T> {
   StreamController<List<SelectionChangeRecord<T>>>? _selectionChangeController;
-  List<SelectionChangeRecord<T>> _selectionChangeRecords = [];
+  List<SelectionChangeRecord<T>>? _selectionChangeRecords;
 
   @override
   bool deliverSelectionChanges() {
-    if (hasSelectionObservers && _selectionChangeRecords.isNotEmpty) {
+    if (hasSelectionObservers &&
+        _selectionChangeRecords != null &&
+        _selectionChangeRecords!.isNotEmpty) {
+      //if (hasSelectionObservers) {
       var records = UnmodifiableListView<SelectionChangeRecord<T>>(
-          _selectionChangeRecords);
-      _selectionChangeRecords.clear();
-      if (_selectionChangeController != null && records.isNotEmpty) {
+          _selectionChangeRecords!);
+      _selectionChangeRecords = null;
+      if (_selectionChangeController != null) {
         _selectionChangeController!.add(records);
       }
       return true;
@@ -46,11 +49,11 @@ abstract class SelectionChangeNotifier<T> implements SelectionModel<T> {
       {Iterable<T> added = const [], Iterable<T> removed = const []}) {
     if (hasSelectionObservers) {
       var record = SelectionChangeRecord<T>(added: added, removed: removed);
-      if (_selectionChangeRecords.isEmpty) {
-        //_selectionChangeRecords = [];
+      if (_selectionChangeRecords == null) {
+        _selectionChangeRecords = [];
         scheduleMicrotask(deliverSelectionChanges);
       }
-      _selectionChangeRecords.add(record);
+      _selectionChangeRecords!.add(record);
     }
   }
 
@@ -82,15 +85,15 @@ class _SelectionChangeRecordImpl<T> extends ChangeRecord
 
   factory _SelectionChangeRecordImpl(
       {Iterable<T> added = const [], Iterable<T> removed = const []}) {
-    added = UnmodifiableListView(added);
-    removed = UnmodifiableListView(removed);
+    var localAdded = UnmodifiableListView(added);
+    var localRemoved = UnmodifiableListView(removed);
     /*    
     added = (added != null ? UnmodifiableListView(added) : const [])
         as Iterable<T>;
     removed = (removed != null ? UnmodifiableListView(removed) : const [])
         as Iterable<T>;
     */
-    return _SelectionChangeRecordImpl._(added, removed);
+    return _SelectionChangeRecordImpl._(localAdded, localRemoved);
   }
 
   _SelectionChangeRecordImpl._(this.added, this.removed);

--- a/angular_components/lib/src/model/selection/single_selection_model_impl.dart
+++ b/angular_components/lib/src/model/selection/single_selection_model_impl.dart
@@ -4,7 +4,7 @@
 
 part of angular_components.model.selection.selection_model;
 
-class _SingleSelectionModelImpl<T> extends Observable<ChangeRecord>
+class _SingleSelectionModelImpl<T> extends PropertyChangeNotifier
     with SelectionChangeNotifier<T>, CastIterable<T>
     implements SingleSelectionModel<T> {
   final KeyProvider<T> _keyOf;

--- a/angular_components/lib/utils/disposer/disposer.dart
+++ b/angular_components/lib/utils/disposer/disposer.dart
@@ -77,17 +77,17 @@ class _SingleFunctionDisposable implements Disposable {
 /// Note that you should not rely on the disposal sequence for each added
 /// [disposable], just treat it random.
 class Disposer implements Disposable {
-  List<DisposeFunction>? _disposeFunctions;
-  List<StreamSubscription<Object?>>? _disposeSubs;
-  List<EventSink<Object?>>? _disposeSinks;
-  List<Disposable>? _disposeDisposables;
+  List<DisposeFunction> _disposeFunctions = [];
+  List<StreamSubscription<dynamic>> _disposeSubs = [];
+  List<EventSink<Object>> _disposeSinks = [];
+  List<Disposable> _disposeDisposables = [];
   final bool _oneShot;
   bool _disposeCalled = false;
 
   /// Pass [oneShot] as true if no disposables are meant to be added after
   /// the dispose method is called.
-  @Deprecated("Please use oneShot or multi instead")
-  Disposer({bool oneShot = false}) : _oneShot = oneShot;
+  //@Deprecated("Please use oneShot or multi instead")
+  //Disposer({bool oneShot = false}) : _oneShot = oneShot;
 
   /// Convenience constructor for one shot mode or single dispose mode.
   Disposer.oneShot() : _oneShot = true;
@@ -107,8 +107,7 @@ class Disposer implements Disposable {
     // is addressed in the language.
     dynamic disposable_ = disposable;
     if (disposable_ is Disposable) {
-      _disposeDisposables ??= [];
-      _disposeDisposables!.add(disposable as Disposable);
+      _disposeDisposables.add(disposable as Disposable);
       _checkIfAlreadyDisposed();
     } else if (disposable_ is StreamSubscription) {
       addStreamSubscription(disposable_);
@@ -123,29 +122,26 @@ class Disposer implements Disposable {
   }
 
   /// Registers [disposable].
-  StreamSubscription<T>? addStreamSubscription<T>(
-      StreamSubscription<T>? disposable) {
-    _disposeSubs ??= [];
-    if (disposable != null) {
-      _disposeSubs?.add(disposable);
-    }
+  StreamSubscription<T> addStreamSubscription<T>(
+      StreamSubscription<T> disposable) {
+    //if (disposable != null) {
+    _disposeSubs.add(disposable);
+    //}
     _checkIfAlreadyDisposed();
     return disposable;
   }
 
   /// Registers [disposable].
   EventSink<T> addEventSink<T>(EventSink<T> disposable) {
-    _disposeSinks ??= [];
-    _disposeSinks!.add(disposable);
+    _disposeSinks.add(disposable as EventSink<Object>);
     _checkIfAlreadyDisposed();
     return disposable;
   }
 
   /// Registers [disposable].
   DisposeFunction addFunction(DisposeFunction disposable) {
-    assert(disposable != null);
-    _disposeFunctions ??= [];
-    _disposeFunctions!.add(disposable);
+    //assert(disposable != null);
+    _disposeFunctions.add(disposable);
     _checkIfAlreadyDisposed();
     return disposable;
   }
@@ -158,34 +154,29 @@ class Disposer implements Disposable {
   @mustCallSuper
   @override
   void dispose() {
-    if (_disposeSubs != null) {
-      int len = _disposeSubs!.length;
-      for (var i = 0; i < len; i++) {
-        _disposeSubs![i].cancel();
-      }
-      _disposeSubs = null;
+    int len = _disposeSubs.length;
+    for (var i = 0; i < len; i++) {
+      _disposeSubs[i].cancel();
     }
-    if (_disposeSinks != null) {
-      int len = _disposeSinks!.length;
-      for (var i = 0; i < len; i++) {
-        _disposeSinks![i].close();
-      }
-      _disposeSinks = null;
+    _disposeSubs.clear();
+    len = _disposeSinks.length;
+    for (var i = 0; i < len; i++) {
+      _disposeSinks[i].close();
     }
-    if (_disposeDisposables != null) {
-      int len = _disposeDisposables!.length;
-      for (var i = 0; i < len; i++) {
-        _disposeDisposables![i].dispose();
-      }
-      _disposeDisposables = null;
+    _disposeSinks.clear();
+
+    len = _disposeDisposables.length;
+    for (var i = 0; i < len; i++) {
+      _disposeDisposables[i].dispose();
     }
-    if (_disposeFunctions != null) {
-      int len = _disposeFunctions!.length;
-      for (var i = 0; i < len; i++) {
-        _disposeFunctions![i]();
-      }
-      _disposeFunctions = null;
+    _disposeDisposables.clear();
+
+    len = _disposeFunctions.length;
+    for (var i = 0; i < len; i++) {
+      _disposeFunctions[i]();
     }
+    _disposeFunctions.clear();
+
     _disposeCalled = true;
   }
 }

--- a/examples/angular_components_example/build.yaml
+++ b/examples/angular_components_example/build.yaml
@@ -12,8 +12,7 @@ targets:
           styleUrls: ["gallery.scss.css"]
           galleryTitle: "AngularDart Gallery"
           examples: "app_layout_example,material_button_example,material_card_example,material_checkbox_example,material_chips_example,material_datepicker_example,material_dialog_example,material_expansionpanel_example,material_icon_example,material_input_example,material_list_example,material_menu_example,material_popup_example,material_progress_example,material_radio_example,material_select_example,material_slider_example,material_spinner_example,material_stepper_example,material_tab_example,material_toggle_example,material_tooltip_example,material_tree_example,material_yes_no_buttons_example,simple_html_example,scorecard_example"
-          sourcecodeUrl: "https://github.com/dukefirehawk/angular_components/tree/master/"
-          #sourcecodeUrl: "https://github.com/dukefirehawk/angular_components/tree/master/"
+          sourcecodeUrl: "https://github.com/angulardart-community/angular_components/tree/dev"
       angular_components|scss_builder:
         enabled: true
       angular_gallery_section:
@@ -25,6 +24,7 @@ targets:
         generate_for:
         - web/main.dart
         options:
+        #  compiler: dart2js
           dart2js_args:
           - --minify
           - --dump-info


### PR DESCRIPTION
Material radio and Material radio group examples are fully functional
* Fixed `select` event trigger, detection and consumption update loop
* Replaced `Observable` with `PropertyChangeNotifier`
* Changed to non-nullable type wherever possible with default values
* Changed `_selectionChangeRecords` in `SelectionChangeNotifier` to nullable type to fix missing notification in an event loop. 