### PR TITLE
Migrated to ngdart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ doc/api/
 
 testing/
 gen_app/
+.DS_Store

--- a/angular_gallery/build.yaml
+++ b/angular_gallery/build.yaml
@@ -3,7 +3,7 @@ targets:
     builders:
       ngcomponents|scss_builder:
         enabled: True
-      angular|angular:
+      ngdart|ngdart:
         generate_for:
           exclude: ["lib/**"]
 
@@ -20,4 +20,4 @@ builders:
       ".html": [".dart"],
       "$web$": ["index.html", "main.dart", "style.scss"]}
     auto_apply: dependents
-    runs_before: ["angular|angular", "ngcomponents|scss_builder"]
+    runs_before: ["ngdart|ngdart", "ngcomponents|scss_builder"]

--- a/angular_gallery/lib/builder/gallery_lib_builder.dart
+++ b/angular_gallery/lib/builder/gallery_lib_builder.dart
@@ -100,11 +100,11 @@ class GalleryLibBuilder extends Builder {
       final summaries = (jsonDecode(summaryContents) as Iterable)
           .map((m) => (m as Map).cast<String, dynamic>());
       examples.addAll(summaries.map((summary) => Example(
-          summary['displayName'],
-          summary['group'],
-          summary['dartImport'],
-          summary['componentClass'],
-          summary['docs'].cast<String>())));
+          summary['displayName'] ?? '',
+          summary['group'] ?? '',
+          summary['dartImport'] ?? '',
+          summary['componentClass'] ?? '',
+          List<String>.from(summary['docs'] ?? {}))));
     }
 
     examples

--- a/angular_gallery/lib/builder/template/gallery.dart.mustache
+++ b/angular_gallery/lib/builder/template/gallery.dart.mustache
@@ -63,7 +63,7 @@ class GalleryComponent implements HighlightProvider {
   //final ItemRenderer<dynamic> _highlightRenderer =
   //    (item) => item is _Example ? item.displayName : item?.toString();
   String? _highlightRenderer(item) {
-    return item is _Example ? item.displayName : item.toString();
+    return item is _Example ? item.displayName : item?.toString();
   }
 
   final List<RouteDefinition> routes = galleryRoutes;

--- a/angular_gallery/lib/builder/template/gallery.dart.mustache
+++ b/angular_gallery/lib/builder/template/gallery.dart.mustache
@@ -1,8 +1,8 @@
 import 'dart:html';
 
-import 'package:angular/angular.dart';
-import 'package:angular_router/angular_router.dart';
-import 'package:angular_forms/angular_forms.dart';
+import 'package:ngdart/angular.dart';
+import 'package:ngrouter/ngrouter.dart';
+import 'package:ngforms/ngforms.dart';
 import 'package:quiver/collection.dart';
 import 'package:ngcomponents/app_layout/material_persistent_drawer.dart';
 import 'package:ngcomponents/content/deferred_content.dart';

--- a/angular_gallery/lib/builder/template/gallery_route_library.dart.mustache
+++ b/angular_gallery/lib/builder/template/gallery_route_library.dart.mustache
@@ -1,4 +1,4 @@
-import 'package:angular_router/angular_router.dart';
+import 'package:ngrouter/ngrouter.dart';
 
 {{# examples }}
 import '{{{ dartImport }}}' deferred as {{ name }};

--- a/angular_gallery/lib/builder/template/home.dart.mustache
+++ b/angular_gallery/lib/builder/template/home.dart.mustache
@@ -1,4 +1,4 @@
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 
 @Component(
     selector: 'home-view',

--- a/angular_gallery/lib/builder/template/main.dart.mustache
+++ b/angular_gallery/lib/builder/template/main.dart.mustache
@@ -14,7 +14,7 @@ import '{{{ bindingImport }}}' as binding;
 
 import 'main.template.dart' as ng;
 
-Logger _logger = Logger("angular_dart_gallery");
+Logger _logger = Logger("ngcomponents_gallery");
 
 //ComponentRef<app.GalleryComponent>? gallery;
 ComponentRef<dynamic>? gallery;

--- a/angular_gallery/lib/builder/template/main.dart.mustache
+++ b/angular_gallery/lib/builder/template/main.dart.mustache
@@ -1,7 +1,7 @@
 import 'dart:html';
 
-import 'package:angular/angular.dart';
-import 'package:angular_router/angular_router.dart';
+import 'package:ngdart/angular.dart';
+import 'package:ngrouter/ngrouter.dart';
 import 'package:logging/logging.dart';
 import 'package:ngcomponents/laminate/popup/module.dart';
 import 'package:ngcomponents/laminate/overlay/module.dart';

--- a/angular_gallery/lib/builders.dart
+++ b/angular_gallery/lib/builders.dart
@@ -22,8 +22,8 @@ Builder galleryAppBuilder(BuilderOptions options) => MultiplexingBuilder([
 /// Builder used to generate files in the gallery library target.
 Builder galleryLibBuilder(BuilderOptions options) => GalleryLibBuilder(
       options.config['galleryTitle'] ?? 'Example Gallery',
-      options.config['styleUrls'].cast<String>(),
-      (options.config['examples'] as String).split(','),
+      (options.config['styleUrls'] as List?)?.cast<String>() ?? [],
+      (options.config['examples'] as String?)?.split(',') ?? [],
     );
 
 /// Builder to generate the Sass styles for syntax highlighting with

--- a/angular_gallery/lib/gallery/gallery_tokens.dart
+++ b/angular_gallery/lib/gallery/gallery_tokens.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/di.dart';
+import 'package:ngdart/di.dart';
 
 const bugUrl = OpaqueToken('bugUrl');
 const sourcecodeUrl = OpaqueToken('sourcecodeUrl');

--- a/angular_gallery/pubspec.yaml
+++ b/angular_gallery/pubspec.yaml
@@ -1,18 +1,20 @@
 name: angular_gallery
 publish_to: none
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  angular: ^7.0.1
+  ngdart: ^7.1.0
   ngcomponents: 
     path: ../ngcomponents
-  angular_forms: ^4.0.0
-  angular_router: ^3.0.0
+  ngforms: ^4.1.0
+  ngrouter: ^3.1.0
   build: ^2.1.1
   build_config: ^1.0.0
   #mustache: ^1.0.0
   mustache_template: ^2.0.0
   ngsecurity:
-    git: https://github.com/angulardart-community/ngsecurity
+    git:
+      url: https://github.com/dukefirehawk/ngsecurity
+      ref: migrated/ngdart
 

--- a/angular_gallery/pubspec.yaml
+++ b/angular_gallery/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   #mustache: ^1.0.0
   mustache_template: ^2.0.0
   ngsecurity:
-    git:
-      url: https://github.com/dukefirehawk/ngsecurity
-      ref: migrated/ngdart
+    git: 
+      url: https://github.com/angulardart-community/ngsecurity
+      ref: main
 

--- a/angular_gallery_section/build.yaml
+++ b/angular_gallery_section/build.yaml
@@ -1,7 +1,7 @@
 targets:
   $default:
     builders:
-      angular|angular:
+      ngdart|ngdart:
         generate_for:
           exclude: [
             "lib/*.dart",
@@ -28,4 +28,4 @@ builders:
       ".dart": [".gallery_info.json", ".api.dart"],
       "$lib$": ["gallery_section.dart", "gallery_section_summary.json"]}
     auto_apply: dependents
-    runs_before: ["angular|angular", "ngcomponents|scss_builder"]
+    runs_before: ["ngdart|ngdart", "ngcomponents|scss_builder"]

--- a/angular_gallery_section/lib/builder/template/component.api.dart.mustache
+++ b/angular_gallery_section/lib/builder/template/component.api.dart.mustache
@@ -1,4 +1,4 @@
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:angular_gallery_section/components/gallery_component/gallery_component.dart';
 import 'package:angular_gallery_section/components/gallery_component/gallery_info.dart';
 

--- a/angular_gallery_section/lib/builder/template/gallery_section.dart.mustache
+++ b/angular_gallery_section/lib/builder/template/gallery_section.dart.mustache
@@ -1,4 +1,4 @@
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/laminate/popup/module.dart';
 import 'package:ngcomponents/model/a11y/focus_indicator_controller.dart';
 

--- a/angular_gallery_section/lib/builder/template/main.dart.mustache
+++ b/angular_gallery_section/lib/builder/template/main.dart.mustache
@@ -1,6 +1,6 @@
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:logging/logging.dart';
 import 'package:ngcomponents/material_datepicker/module.dart';
 import 'package:angular_gallery/gallery/gallery_tokens.dart';

--- a/angular_gallery_section/lib/components/content/delayed_content.dart
+++ b/angular_gallery_section/lib/components/content/delayed_content.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_progress/material_progress.dart';
 
 /// `delayed-content` is a simple pass-thru content container which, when

--- a/angular_gallery_section/lib/components/content/named_content.dart
+++ b/angular_gallery_section/lib/components/content/named_content.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 
 /// Simple pass-thru content container which announces its construction and
 /// displays a label (in a <p> tag) above the content.

--- a/angular_gallery_section/lib/components/gallery_component/documentation_component.dart
+++ b/angular_gallery_section/lib/components/gallery_component/documentation_component.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngsecurity/security.dart';
 import 'package:angular_gallery_section/components/gallery_component/gallery_info.dart';
 import 'package:sanitize_html/sanitize_html.dart' show sanitizeHtml;

--- a/angular_gallery_section/lib/components/gallery_component/gallery_component.dart
+++ b/angular_gallery_section/lib/components/gallery_component/gallery_component.dart
@@ -6,7 +6,7 @@
 library angular_components.scaffolding.gallery_section.components.gallery_component;
 
 import 'dart:html';
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:js/js.dart';
 import 'package:ngcomponents/button_decorator/button_decorator.dart';
 import 'package:ngcomponents/dynamic_component/dynamic_component.dart';

--- a/angular_gallery_section/lib/components/gallery_component/gallery_info.dart
+++ b/angular_gallery_section/lib/components/gallery_component/gallery_info.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:angular_gallery_section/components/gallery_component/documentation_info.dart';
 
 // This needs to be a seperate build target for the builders but all runtime

--- a/angular_gallery_section/lib/resolved_config.dart
+++ b/angular_gallery_section/lib/resolved_config.dart
@@ -47,7 +47,7 @@ class ResolvedConfig {
 
   /// Constructs a new [ResolvedConfig] from a decoded json map.
   ResolvedConfig.fromJson(Map<String, dynamic> jsonMap) {
-    displayName = jsonMap['displayName'] as String;
+    displayName = jsonMap['displayName'] as String? ?? '';
     group = jsonMap['group'] as String?;
 
     docs = (jsonMap['docs'] as Iterable?)

--- a/angular_gallery_section/pubspec.yaml
+++ b/angular_gallery_section/pubspec.yaml
@@ -2,11 +2,11 @@ name: angular_gallery_section
 publish_to: none
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  analyzer: ^2.4.0
-  angular: ^7.0.1
+  analyzer: ^4.0.0
+  ngdart: ^7.1.0
   ngcomponents: 
     path: ../ngcomponents
   angular_gallery:
@@ -14,13 +14,14 @@ dependencies:
   build: ^2.1.1
   build_config: ^1.0.0
   glob: ^2.0.2
-  markdown: ^4.0.0
+  markdown: ^5.0.0
   mustache_template: ^2.0.0
   path: ^1.6.1
   sass: '>=1.15.3 <2.0.0'
   sanitize_html: ^2.0.0
 
   ngsecurity: 
-    git: https://github.com/angulardart-community/ngsecurity
-
+    git:
+      url: https://github.com/dukefirehawk/ngsecurity
+      ref: migrated/ngdart
     

--- a/angular_gallery_section/pubspec.yaml
+++ b/angular_gallery_section/pubspec.yaml
@@ -22,6 +22,6 @@ dependencies:
 
   ngsecurity: 
     git:
-      url: https://github.com/dukefirehawk/ngsecurity
-      ref: migrated/ngdart
+      url: https://github.com/angulardart-community/ngsecurity
+      ref: main
     

--- a/examples/angular_components_example/build.yaml
+++ b/examples/angular_components_example/build.yaml
@@ -5,7 +5,7 @@ global_options:
 targets:
   $default:
     builders:
-      angular|angular:
+      ngdart|ngdart:
         enabled: true
       angular_gallery|angular_gallery:
         options:
@@ -24,7 +24,7 @@ targets:
         generate_for:
         - web/main.dart
         options:
-        #  compiler: dart2js
+          compiler: dart2js
           dart2js_args:
           - --minify
           - --dump-info

--- a/examples/angular_components_example/pubspec.yaml
+++ b/examples/angular_components_example/pubspec.yaml
@@ -2,10 +2,10 @@ name: ngcomponents_example
 publish_to: none
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  angular: ^7.0.1
+  ngdart: ^7.1.0
   ngcomponents:
     path: ../../ngcomponents
   angular_gallery:

--- a/examples/app_layout_example/lib/app_layout_example.dart
+++ b/examples/app_layout_example/lib/app_layout_example.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/app_layout/material_persistent_drawer.dart';
 import 'package:ngcomponents/content/deferred_content.dart';
 import 'package:ngcomponents/material_button/material_button.dart';

--- a/examples/app_layout_example/lib/mobile_app_layout_example.dart
+++ b/examples/app_layout_example/lib/mobile_app_layout_example.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/app_layout/material_persistent_drawer.dart';
 import 'package:ngcomponents/app_layout/material_temporary_drawer.dart';
 import 'package:ngcomponents/content/deferred_content.dart';

--- a/examples/app_layout_example/lib/stacking_drawer_example.dart
+++ b/examples/app_layout_example/lib/stacking_drawer_example.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/app_layout/material_stackable_drawer.dart';
 import 'package:ngcomponents/content/deferred_content.dart';
 import 'package:ngcomponents/material_button/material_button.dart';

--- a/examples/app_layout_example/pubspec.yaml
+++ b/examples/app_layout_example/pubspec.yaml
@@ -2,10 +2,10 @@ name: app_layout_example
 publish_to: none
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  angular: ^7.0.1
+  ngdart: ^7.1.0
   ngcomponents: 
      path: ../../ngcomponents
   angular_gallery:
@@ -13,4 +13,5 @@ dependencies:
   angular_gallery_section:
     path: ../../angular_gallery_section
   build_config: ^1.0.0
+  
    

--- a/examples/material_button_example/lib/buttons.dart
+++ b/examples/material_button_example/lib/buttons.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_button/material_button.dart';
 import 'package:ngcomponents/material_icon/material_icon.dart';
 

--- a/examples/material_button_example/lib/material_button_example.dart
+++ b/examples/material_button_example/lib/material_button_example.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_button/material_button.dart';
 import 'package:ngcomponents/material_button/material_fab.dart';
 import 'buttons.dart';

--- a/examples/material_button_example/pubspec.yaml
+++ b/examples/material_button_example/pubspec.yaml
@@ -2,10 +2,10 @@ name: material_button_example
 publish_to: none
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  angular: ^7.0.1
+  ngdart: ^7.1.0
   ngcomponents:
     path: ../../ngcomponents
   angular_gallery:

--- a/examples/material_card_example/lib/material_card_example.dart
+++ b/examples/material_card_example/lib/material_card_example.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_button/material_button.dart';
 import 'package:ngcomponents/material_icon/material_icon.dart';
 import 'package:angular_gallery_section/annotation/gallery_section_config.dart';

--- a/examples/material_card_example/pubspec.yaml
+++ b/examples/material_card_example/pubspec.yaml
@@ -2,10 +2,10 @@ name: material_card_example
 publish_to: none
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  angular: ^7.0.1
+  ngdart: ^7.1.0
   ngcomponents: 
     path: ../../ngcomponents
   angular_gallery:

--- a/examples/material_checkbox_example/lib/material_checkbox_example.dart
+++ b/examples/material_checkbox_example/lib/material_checkbox_example.dart
@@ -2,8 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
-import 'package:angular_forms/angular_forms.dart';
+import 'package:ngdart/angular.dart';
+import 'package:ngforms/ngforms.dart';
 import 'package:ngcomponents/material_button/material_button.dart';
 import 'package:ngcomponents/material_checkbox/material_checkbox.dart';
 import 'package:ngcomponents/material_icon/material_icon.dart';

--- a/examples/material_checkbox_example/pubspec.yaml
+++ b/examples/material_checkbox_example/pubspec.yaml
@@ -2,13 +2,13 @@ name: material_checkbox_example
 publish_to: none
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  angular: ^7.0.1
+  ngdart: ^7.1.0
   ngcomponents:
     path: ../../ngcomponents
-  angular_forms: ^4.0.0
+  ngforms: ^4.1.0
   angular_gallery:
     path: ../../angular_gallery
   angular_gallery_section:

--- a/examples/material_chips_example/lib/material_chips_demo.dart
+++ b/examples/material_chips_example/lib/material_chips_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/button_decorator/button_decorator.dart';
 import 'package:ngcomponents/material_button/material_button.dart';
 import 'package:ngcomponents/material_chips/material_chip.dart';

--- a/examples/material_chips_example/pubspec.yaml
+++ b/examples/material_chips_example/pubspec.yaml
@@ -2,10 +2,10 @@ name: material_chips_example
 publish_to: none
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  angular: ^7.0.1
+  ngdart: ^7.1.0
   ngcomponents:
     path: ../../ngcomponents
   angular_gallery:

--- a/examples/material_datepicker_example/lib/date_input_demo.dart
+++ b/examples/material_datepicker_example/lib/date_input_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_datepicker/date_input.dart';
 import 'package:ngcomponents/material_datepicker/module.dart';
 import 'package:ngcomponents/material_input/material_input.dart';

--- a/examples/material_datepicker_example/lib/date_range_input_demo.dart
+++ b/examples/material_datepicker_example/lib/date_range_input_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_datepicker/date_range_input.dart';
 import 'package:ngcomponents/material_datepicker/module.dart';
 import 'package:ngcomponents/model/date/date.dart';

--- a/examples/material_datepicker_example/lib/material_calendar_picker_demo.dart
+++ b/examples/material_datepicker_example/lib/material_calendar_picker_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_datepicker/calendar.dart';
 import 'package:ngcomponents/material_datepicker/material_calendar_picker.dart';
 import 'package:ngcomponents/material_datepicker/module.dart';

--- a/examples/material_datepicker_example/lib/material_date_range_picker_demo.dart
+++ b/examples/material_datepicker_example/lib/material_date_range_picker_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:quiver/time.dart';
 import 'package:ngcomponents/laminate/popup/popup.dart';
 import 'package:ngcomponents/material_checkbox/material_checkbox.dart';

--- a/examples/material_datepicker_example/lib/material_date_time_picker_demo.dart
+++ b/examples/material_datepicker_example/lib/material_date_time_picker_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_datepicker/material_date_time_picker.dart';
 import 'package:ngcomponents/material_datepicker/module.dart';
 import 'package:ngcomponents/utils/browser/window/module.dart';

--- a/examples/material_datepicker_example/lib/material_datepicker_demo.dart
+++ b/examples/material_datepicker_example/lib/material_datepicker_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:quiver/time.dart';
 import 'package:ngcomponents/material_datepicker/date_range_input.dart';
 import 'package:ngcomponents/material_datepicker/material_datepicker.dart';

--- a/examples/material_datepicker_example/lib/material_month_picker_demo.dart
+++ b/examples/material_datepicker_example/lib/material_month_picker_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_datepicker/calendar.dart';
 import 'package:ngcomponents/material_datepicker/date_range_input.dart';
 import 'package:ngcomponents/material_datepicker/material_month_picker.dart';

--- a/examples/material_datepicker_example/lib/material_time_picker_demo.dart
+++ b/examples/material_datepicker_example/lib/material_time_picker_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_datepicker/material_time_picker.dart';
 import 'package:ngcomponents/material_datepicker/module.dart';
 import 'package:ngcomponents/utils/browser/window/module.dart';

--- a/examples/material_datepicker_example/pubspec.yaml
+++ b/examples/material_datepicker_example/pubspec.yaml
@@ -2,10 +2,10 @@ name: material_datepicker_example
 publish_to: none
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  angular: ^7.0.1
+  ngdart: ^7.1.0
   ngcomponents:
     path: ../../ngcomponents
   angular_gallery:

--- a/examples/material_dialog_example/lib/material_dialog_example.dart
+++ b/examples/material_dialog_example/lib/material_dialog_example.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/auto_dismiss/auto_dismiss.dart';
 import 'package:ngcomponents/focus/focus.dart';
 import 'package:ngcomponents/laminate/components/modal/modal.dart';

--- a/examples/material_dialog_example/pubspec.yaml
+++ b/examples/material_dialog_example/pubspec.yaml
@@ -2,10 +2,10 @@ name: material_dialog_example
 publish_to: none
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  angular: ^7.0.1
+  ngdart: ^7.1.0
   ngcomponents:
     path: ../../ngcomponents
   angular_gallery:

--- a/examples/material_expansionpanel_example/lib/material_expansionpanel_example.dart
+++ b/examples/material_expansionpanel_example/lib/material_expansionpanel_example.dart
@@ -4,8 +4,8 @@
 
 import 'dart:async';
 
-import 'package:angular/angular.dart';
-//import 'package:angular_forms/angular_forms.dart';
+import 'package:ngdart/angular.dart';
+//import 'package:ngforms/ngforms.dart';
 import 'package:ngcomponents/focus/focus.dart';
 import 'package:ngcomponents/focus/focus_list.dart';
 import 'package:ngcomponents/laminate/components/modal/modal.dart';

--- a/examples/material_expansionpanel_example/pubspec.yaml
+++ b/examples/material_expansionpanel_example/pubspec.yaml
@@ -2,13 +2,13 @@ name: material_expansionpanel_example
 publish_to: none
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  angular: ^7.0.1
+  ngdart: ^7.1.0
   ngcomponents:
     path: ../../ngcomponents
-  angular_forms: ^4.0.0
+  ngforms: ^4.1.0
   angular_gallery:
     path: ../../angular_gallery
   angular_gallery_section:

--- a/examples/material_icon_example/lib/material_icon_demo.dart
+++ b/examples/material_icon_example/lib/material_icon_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_button/material_button.dart';
 import 'package:ngcomponents/material_icon/material_icon.dart';
 import 'package:ngcomponents/material_input/material_input.dart';

--- a/examples/material_icon_example/pubspec.yaml
+++ b/examples/material_icon_example/pubspec.yaml
@@ -2,10 +2,10 @@ name: material_icon_example
 publish_to: none
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  angular: ^7.0.1
+  ngdart: ^7.1.0
   ngcomponents:
     path: ../../ngcomponents
   angular_gallery:

--- a/examples/material_input_example/lib/material_auto_suggest_input_full_demo.dart
+++ b/examples/material_input_example/lib/material_auto_suggest_input_full_demo.dart
@@ -2,8 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
-import 'package:angular_forms/angular_forms.dart';
+import 'package:ngdart/angular.dart';
+import 'package:ngforms/ngforms.dart';
 import 'package:ngcomponents/laminate/enums/alignment.dart';
 import 'package:ngcomponents/material_button/material_button.dart';
 import 'package:ngcomponents/material_checkbox/material_checkbox.dart';

--- a/examples/material_input_example/lib/material_auto_suggest_input_simple_demo.dart
+++ b/examples/material_input_example/lib/material_auto_suggest_input_simple_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_input/material_auto_suggest_input.dart';
 
 @Component(

--- a/examples/material_input_example/lib/material_input_demo.dart
+++ b/examples/material_input_example/lib/material_input_demo.dart
@@ -9,7 +9,6 @@ import 'package:ngcomponents/material_button/material_button.dart';
 import 'package:ngcomponents/material_icon/material_icon.dart';
 import 'package:ngcomponents/material_input/material_input.dart';
 import 'package:ngcomponents/material_input/material_input_auto_select.dart';
-import 'package:ngcomponents/material_input/material_input_multiline.dart';
 import 'package:ngcomponents/material_input/material_number_accessor.dart';
 import 'package:ngcomponents/material_tooltip/material_tooltip.dart';
 

--- a/examples/material_input_example/lib/material_input_demo.dart
+++ b/examples/material_input_example/lib/material_input_demo.dart
@@ -2,8 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
-import 'package:angular_forms/angular_forms.dart';
+import 'package:ngdart/angular.dart';
+import 'package:ngforms/ngforms.dart';
 import 'package:ngcomponents/focus/focus.dart';
 import 'package:ngcomponents/material_button/material_button.dart';
 import 'package:ngcomponents/material_icon/material_icon.dart';

--- a/examples/material_input_example/lib/material_input_mixins.dart
+++ b/examples/material_input_example/lib/material_input_mixins.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_input/material_input.dart';
 
 @Component(

--- a/examples/material_input_example/lib/material_input_number_value_accessor_demo.dart
+++ b/examples/material_input_example/lib/material_input_number_value_accessor_demo.dart
@@ -2,8 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
-import 'package:angular_forms/angular_forms.dart';
+import 'package:ngdart/angular.dart';
+import 'package:ngforms/ngforms.dart';
 import 'package:intl/intl.dart';
 import 'package:ngcomponents/material_button/material_fab.dart';
 import 'package:ngcomponents/material_input/material_number_accessor.dart';

--- a/examples/material_input_example/lib/material_percent_input_demo.dart
+++ b/examples/material_input_example/lib/material_percent_input_demo.dart
@@ -2,8 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
-import 'package:angular_forms/angular_forms.dart';
+import 'package:ngdart/angular.dart';
+import 'package:ngforms/ngforms.dart';
 import 'package:ngcomponents/material_input/material_percent_directive.dart';
 
 @Component(

--- a/examples/material_input_example/pubspec.yaml
+++ b/examples/material_input_example/pubspec.yaml
@@ -2,13 +2,13 @@ name: material_input_example
 publish_to: none
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  angular: ^7.0.1
+  ngdart: ^7.1.0
   ngcomponents:
     path: ../../ngcomponents
-  angular_forms: ^4.0.0
+  ngforms: ^4.1.0
   angular_gallery:
     path: ../../angular_gallery
   angular_gallery_section:

--- a/examples/material_list_example/lib/material_list_demo.dart
+++ b/examples/material_list_example/lib/material_list_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/focus/focus_item.dart';
 import 'package:ngcomponents/focus/focus_list.dart';
 import 'package:ngcomponents/material_icon/material_icon.dart';

--- a/examples/material_list_example/pubspec.yaml
+++ b/examples/material_list_example/pubspec.yaml
@@ -2,10 +2,10 @@ name: material_list_example
 publish_to: none
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  angular: ^7.0.1
+  ngdart: ^7.1.0
   ngcomponents:
     path: ../../ngcomponents
   angular_gallery:

--- a/examples/material_menu_example/lib/material_fab_menu_demo.dart
+++ b/examples/material_menu_example/lib/material_fab_menu_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_menu/material_fab_menu.dart';
 import 'package:ngcomponents/model/menu/menu.dart';
 import 'package:ngcomponents/model/ui/icon.dart';

--- a/examples/material_menu_example/lib/material_menu_demo.dart
+++ b/examples/material_menu_example/lib/material_menu_demo.dart
@@ -4,7 +4,7 @@
 
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/laminate/overlay/zindexer.dart';
 import 'package:ngcomponents/laminate/popup/module.dart';
 import 'package:ngcomponents/material_icon/material_icon.dart';

--- a/examples/material_menu_example/pubspec.yaml
+++ b/examples/material_menu_example/pubspec.yaml
@@ -2,10 +2,10 @@ name: material_menu_example
 publish_to: none
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  angular: ^7.0.1
+  ngdart: ^7.1.0
   ngcomponents:
     path: ../../ngcomponents
   angular_gallery:

--- a/examples/material_popup_example/lib/material_popup_example.dart
+++ b/examples/material_popup_example/lib/material_popup_example.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/content/deferred_content.dart';
 import 'package:ngcomponents/laminate/enums/alignment.dart';
 import 'package:ngcomponents/laminate/overlay/module.dart';

--- a/examples/material_popup_example/pubspec.yaml
+++ b/examples/material_popup_example/pubspec.yaml
@@ -2,10 +2,10 @@ name: material_popup_example
 publish_to: none
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  angular: ^7.0.1
+  ngdart: ^7.1.0
   ngcomponents:
     path: ../../ngcomponents
   angular_gallery:

--- a/examples/material_progress_example/lib/material_progress_demo.dart
+++ b/examples/material_progress_example/lib/material_progress_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_progress/material_progress.dart';
 import 'package:angular_gallery_section/annotation/gallery_section_config.dart';
 

--- a/examples/material_progress_example/pubspec.yaml
+++ b/examples/material_progress_example/pubspec.yaml
@@ -2,10 +2,10 @@ name: material_progress_example
 publish_to: none
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  angular: ^7.0.1
+  ngdart: ^7.1.0
   ngcomponents:
     path: ../../ngcomponents
   angular_gallery:

--- a/examples/material_radio_example/lib/material_radio_example.dart
+++ b/examples/material_radio_example/lib/material_radio_example.dart
@@ -2,8 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
-import 'package:angular_forms/angular_forms.dart';
+import 'package:ngdart/angular.dart';
+import 'package:ngforms/ngforms.dart';
 import 'package:ngcomponents/material_icon/material_icon.dart';
 import 'package:ngcomponents/material_radio/material_radio.dart';
 import 'package:ngcomponents/material_radio/material_radio_group.dart';

--- a/examples/material_radio_example/pubspec.yaml
+++ b/examples/material_radio_example/pubspec.yaml
@@ -2,13 +2,13 @@ name: material_radio_example
 publish_to: none
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  angular: ^7.0.1
+  ngdart: ^7.1.0
   ngcomponents:
     path: ../../ngcomponents
-  angular_forms: ^4.0.0
+  ngforms: ^4.1.0
   angular_gallery:
     path: ../../angular_gallery
   angular_gallery_section:

--- a/examples/material_select_example/lib/material_dropdown_select_full_demo.dart
+++ b/examples/material_select_example/lib/material_dropdown_select_full_demo.dart
@@ -5,8 +5,8 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
-//import 'package:angular_forms/angular_forms.dart';
+import 'package:ngdart/angular.dart';
+//import 'package:ngforms/ngforms.dart';
 import 'package:ngcomponents/laminate/enums/alignment.dart';
 import 'package:ngcomponents/laminate/popup/module.dart';
 import 'package:ngcomponents/material_checkbox/material_checkbox.dart';

--- a/examples/material_select_example/lib/material_dropdown_select_full_demo.dart
+++ b/examples/material_select_example/lib/material_dropdown_select_full_demo.dart
@@ -322,8 +322,7 @@ class ExampleSelectionOptions extends StringSelectionOptions<Language>
       : super.withOptionGroups(optionGroups as List<OptionGroup<Language>>,
             toFilterableString: (Language option) => option.toString());
   @override
-  SelectableOption getSelectable(Language item) =>
-      item is Language && item.code.contains('en')
-          ? SelectableOption.Disabled
-          : SelectableOption.Selectable;
+  SelectableOption getSelectable(Language item) => item.code.contains('en')
+      ? SelectableOption.Disabled
+      : SelectableOption.Selectable;
 }

--- a/examples/material_select_example/lib/material_dropdown_select_simple_demo.dart
+++ b/examples/material_select_example/lib/material_dropdown_select_simple_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_select/material_dropdown_select.dart';
 
 @Component(

--- a/examples/material_select_example/lib/material_select_demo.dart
+++ b/examples/material_select_example/lib/material_select_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/focus/focus_item.dart';
 import 'package:ngcomponents/focus/focus_list.dart';
 import 'package:ngcomponents/material_select/display_name.dart';

--- a/examples/material_select_example/pubspec.yaml
+++ b/examples/material_select_example/pubspec.yaml
@@ -2,13 +2,13 @@ name: material_select_example
 publish_to: none
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  angular: ^7.0.1
+  ngdart: ^7.1.0
   ngcomponents:
     path: ../../ngcomponents
-  angular_forms: ^4.0.0
+  ngforms: ^4.1.0
   angular_gallery:
     path: ../../angular_gallery
   angular_gallery_section:

--- a/examples/material_slider_example/lib/material_slider_example.dart
+++ b/examples/material_slider_example/lib/material_slider_example.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_slider/material_slider.dart';
 import 'package:ngcomponents/material_toggle/material_toggle.dart';
 import 'package:angular_gallery_section/annotation/gallery_section_config.dart';

--- a/examples/material_slider_example/pubspec.yaml
+++ b/examples/material_slider_example/pubspec.yaml
@@ -2,10 +2,10 @@ name: material_slider_example
 publish_to: none
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  angular: ^7.0.1
+  ngdart: ^7.1.0
   ngcomponents:
     path: ../../ngcomponents
   angular_gallery:

--- a/examples/material_spinner_example/lib/material_spinner_example.dart
+++ b/examples/material_spinner_example/lib/material_spinner_example.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_spinner/material_spinner.dart';
 import 'package:angular_gallery_section/annotation/gallery_section_config.dart';
 

--- a/examples/material_spinner_example/pubspec.yaml
+++ b/examples/material_spinner_example/pubspec.yaml
@@ -2,10 +2,10 @@ name: material_spinner_example
 publish_to: none
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  angular: ^7.0.1
+  ngdart: ^7.1.0
   ngcomponents:
     path: ../../ngcomponents
   angular_gallery:

--- a/examples/material_stepper_example/lib/material_stepper_demo.dart
+++ b/examples/material_stepper_example/lib/material_stepper_demo.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_button/material_button.dart';
 import 'package:ngcomponents/material_stepper/material_step.dart';
 import 'package:ngcomponents/material_stepper/material_stepper.dart';

--- a/examples/material_stepper_example/pubspec.yaml
+++ b/examples/material_stepper_example/pubspec.yaml
@@ -2,10 +2,10 @@ name: material_stepper_example
 publish_to: none
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  angular: ^7.0.1
+  ngdart: ^7.1.0
   ngcomponents:
     path: ../../ngcomponents
   angular_gallery:

--- a/examples/material_tab_example/lib/material_tab_panel_example.dart
+++ b/examples/material_tab_example/lib/material_tab_panel_example.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/annotations/rtl_annotation.dart';
 import 'package:ngcomponents/content/deferred_content.dart';
 import 'package:ngcomponents/material_tab/material_tab.dart';

--- a/examples/material_tab_example/lib/material_tab_strip_example.dart
+++ b/examples/material_tab_example/lib/material_tab_strip_example.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/annotations/rtl_annotation.dart';
 import 'package:ngcomponents/material_tab/fixed_material_tab_strip.dart';
 import 'package:ngcomponents/material_tab/tab_change_event.dart';

--- a/examples/material_tab_example/lib/material_tab_strip_mixin_example.dart
+++ b/examples/material_tab_example/lib/material_tab_strip_mixin_example.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/annotations/rtl_annotation.dart';
 import 'package:ngcomponents/material_tab/fixed_material_tab_strip.dart';
 import 'package:ngcomponents/utils/browser/dom_service/angular_2.dart';

--- a/examples/material_tab_example/pubspec.yaml
+++ b/examples/material_tab_example/pubspec.yaml
@@ -2,10 +2,10 @@ name: material_tab_example
 publish_to: none
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  angular: ^7.0.1
+  ngdart: ^7.1.0
   ngcomponents:
     path: ../../ngcomponents
   angular_gallery:

--- a/examples/material_toggle_example/lib/material_toggle_example.dart
+++ b/examples/material_toggle_example/lib/material_toggle_example.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_toggle/material_toggle.dart';
 import 'package:angular_gallery_section/annotation/gallery_section_config.dart';
 

--- a/examples/material_toggle_example/pubspec.yaml
+++ b/examples/material_toggle_example/pubspec.yaml
@@ -2,10 +2,10 @@ name: material_toggle_example
 publish_to: none
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  angular: ^7.0.1
+  ngdart: ^7.1.0
   ngcomponents:
     path: ../../ngcomponents
   angular_gallery:

--- a/examples/material_tooltip_example/lib/material_tooltip_example.dart
+++ b/examples/material_tooltip_example/lib/material_tooltip_example.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/content/deferred_content.dart';
 import 'package:ngcomponents/focus/keyboard_only_focus_indicator.dart';
 import 'package:ngcomponents/laminate/enums/alignment.dart';

--- a/examples/material_tooltip_example/pubspec.yaml
+++ b/examples/material_tooltip_example/pubspec.yaml
@@ -2,10 +2,10 @@ name: material_tooltip_example
 publish_to: none
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  angular: ^7.0.1
+  ngdart: ^7.1.0
   ngcomponents:
     path: ../../ngcomponents
   angular_gallery:

--- a/examples/material_tree_example/lib/src/material_tree_component_renderer.dart
+++ b/examples/material_tree_example/lib/src/material_tree_component_renderer.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_icon/material_icon.dart';
 import 'package:ngcomponents/model/ui/has_renderer.dart';
 

--- a/examples/material_tree_example/lib/src/material_tree_dropdown_multi_clear_demo.dart
+++ b/examples/material_tree_example/lib/src/material_tree_dropdown_multi_clear_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_button/material_button.dart';
 import 'package:ngcomponents/material_tree/material_tree.dart';
 import 'material_tree_demo_options.dart' as data;

--- a/examples/material_tree_example/lib/src/material_tree_dropdown_multi_demo.dart
+++ b/examples/material_tree_example/lib/src/material_tree_dropdown_multi_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_tree/material_tree.dart';
 import 'material_tree_demo_options.dart' as data;
 import 'package:ngcomponents/model/selection/selection_model.dart';

--- a/examples/material_tree_example/lib/src/material_tree_dropdown_single_demo.dart
+++ b/examples/material_tree_example/lib/src/material_tree_dropdown_single_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_tree/material_tree.dart';
 import 'material_tree_demo_options.dart' as data;
 import 'package:ngcomponents/model/selection/selection_model.dart';

--- a/examples/material_tree_example/lib/src/material_tree_flat_filter_demo.dart
+++ b/examples/material_tree_example/lib/src/material_tree_flat_filter_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_tree/material_tree.dart';
 import 'material_tree_demo_options.dart' as data;
 import 'package:ngcomponents/model/selection/selection_model.dart';

--- a/examples/material_tree_example/lib/src/material_tree_flat_multi_demo.dart
+++ b/examples/material_tree_example/lib/src/material_tree_flat_multi_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_tree/material_tree.dart';
 import 'material_tree_demo_options.dart' as data;
 import 'package:ngcomponents/model/selection/selection_model.dart';

--- a/examples/material_tree_example/lib/src/material_tree_flat_readonly_demo.dart
+++ b/examples/material_tree_example/lib/src/material_tree_flat_readonly_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_tree/material_tree.dart';
 import 'material_tree_demo_options.dart' as data;
 import 'package:ngcomponents/model/selection/selection_options.dart';

--- a/examples/material_tree_example/lib/src/material_tree_flat_selectable_demo.dart
+++ b/examples/material_tree_example/lib/src/material_tree_flat_selectable_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_tree/material_tree.dart';
 import 'material_tree_demo_options.dart' as data;
 import 'package:ngcomponents/model/selection/selection_model.dart';

--- a/examples/material_tree_example/lib/src/material_tree_nested_component_rendering_demo.dart
+++ b/examples/material_tree_example/lib/src/material_tree_nested_component_rendering_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_tree/material_tree.dart';
 import 'material_tree_demo_options.dart' as data;
 import 'package:ngcomponents/model/selection/selection_options.dart';

--- a/examples/material_tree_example/lib/src/material_tree_nested_expansion_state_demo.dart
+++ b/examples/material_tree_example/lib/src/material_tree_nested_expansion_state_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_tree/material_tree.dart';
 import 'material_tree_demo_options.dart' as data;
 import 'package:ngcomponents/model/selection/selection_model.dart';

--- a/examples/material_tree_example/lib/src/material_tree_nested_filter_demo.dart
+++ b/examples/material_tree_example/lib/src/material_tree_nested_filter_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_tree/material_tree.dart';
 import 'material_tree_demo_options.dart' as data;
 import 'package:ngcomponents/model/selection/selection_model.dart';

--- a/examples/material_tree_example/lib/src/material_tree_nested_filter_in_popup_demo.dart
+++ b/examples/material_tree_example/lib/src/material_tree_nested_filter_in_popup_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_tree/material_tree.dart';
 import 'material_tree_demo_options.dart' as data;
 import 'package:ngcomponents/model/selection/selection_model.dart';

--- a/examples/material_tree_example/lib/src/material_tree_nested_item_rendering_demo.dart
+++ b/examples/material_tree_example/lib/src/material_tree_nested_item_rendering_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_tree/material_tree.dart';
 import 'material_tree_demo_options.dart' as data;
 import 'package:ngcomponents/model/selection/selection_options.dart';

--- a/examples/material_tree_example/lib/src/material_tree_nested_multi_demo.dart
+++ b/examples/material_tree_example/lib/src/material_tree_nested_multi_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_tree/material_tree.dart';
 import 'material_tree_demo_options.dart' as data;
 import 'package:ngcomponents/model/selection/selection_model.dart';

--- a/examples/material_tree_example/lib/src/material_tree_nested_single_demo.dart
+++ b/examples/material_tree_example/lib/src/material_tree_nested_single_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_tree/material_tree.dart';
 import 'material_tree_demo_options.dart' as data;
 import 'package:ngcomponents/model/selection/selection_model.dart';

--- a/examples/material_tree_example/lib/src/material_tree_nested_single_divider_demo.dart
+++ b/examples/material_tree_example/lib/src/material_tree_nested_single_divider_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_radio/material_radio.dart';
 import 'package:ngcomponents/material_radio/material_radio_group.dart';
 import 'package:ngcomponents/material_tree/material_tree.dart';

--- a/examples/material_tree_example/lib/src/material_tree_nested_single_parent_selectable_demo.dart
+++ b/examples/material_tree_example/lib/src/material_tree_nested_single_parent_selectable_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_tree/material_tree.dart';
 import 'material_tree_demo_options.dart' as data;
 import 'package:ngcomponents/model/selection/selection_model.dart';

--- a/examples/material_tree_example/lib/src/material_tree_view_more_demo.dart
+++ b/examples/material_tree_example/lib/src/material_tree_view_more_demo.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_tree/material_tree.dart';
 import 'material_tree_demo_options.dart' as data;
 import 'package:ngcomponents/model/selection/selection_model.dart';

--- a/examples/material_tree_example/pubspec.yaml
+++ b/examples/material_tree_example/pubspec.yaml
@@ -2,10 +2,10 @@ name: material_tree_example
 publish_to: none
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  angular: ^7.0.1
+  ngdart: ^7.1.0
   ngcomponents:
     path: ../../ngcomponents
   angular_gallery:

--- a/examples/material_yes_no_buttons_example/lib/material_yes_no_buttons_example.dart
+++ b/examples/material_yes_no_buttons_example/lib/material_yes_no_buttons_example.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_yes_no_buttons/material_yes_no_buttons.dart';
 import 'package:angular_gallery_section/annotation/gallery_section_config.dart';
 

--- a/examples/material_yes_no_buttons_example/pubspec.yaml
+++ b/examples/material_yes_no_buttons_example/pubspec.yaml
@@ -2,10 +2,10 @@ name: material_yes_no_buttons_example
 publish_to: none
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  angular: ^7.0.1
+  ngdart: ^7.1.0
   ngcomponents:
     path: ../../ngcomponents
   angular_gallery:

--- a/examples/scorecard_example/lib/scorecard_demo.dart
+++ b/examples/scorecard_example/lib/scorecard_demo.dart
@@ -2,8 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
-import 'package:angular_forms/angular_forms.dart';
+import 'package:ngdart/angular.dart';
+import 'package:ngforms/ngforms.dart';
 import 'package:ngcomponents/annotations/rtl_annotation.dart';
 import 'package:ngcomponents/material_input/material_number_accessor.dart';
 import 'package:angular_gallery_section/annotation/gallery_section_config.dart';

--- a/examples/scorecard_example/pubspec.yaml
+++ b/examples/scorecard_example/pubspec.yaml
@@ -2,13 +2,13 @@ name: scorecard_example
 publish_to: none
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  angular: ^7.0.1
+  ngdart: ^7.1.0
   ngcomponents:
     path: ../../ngcomponents
-  angular_forms: ^4.0.0
+  ngforms: ^4.1.0
   angular_gallery:
     path: ../../angular_gallery
   angular_gallery_section:

--- a/examples/simple_html_example/lib/basic_example/simple_html_example.dart
+++ b/examples/simple_html_example/lib/basic_example/simple_html_example.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart' show Component;
+import 'package:ngdart/angular.dart' show Component;
 import 'package:ngcomponents/simple_html/simple_html.dart'
     show SimpleHtmlComponent, SimpleHtmlBlockComponent;
 

--- a/examples/simple_html_example/lib/custom_whitelist_example/simple_html_custom_whitelist_example.dart
+++ b/examples/simple_html_example/lib/custom_whitelist_example/simple_html_custom_whitelist_example.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart' show Component, FactoryProvider;
+import 'package:ngdart/angular.dart' show Component, FactoryProvider;
 import 'package:ngcomponents/simple_html/simple_html.dart'
     show SimpleHtmlComponent, simpleHtmlUriWhitelist;
 

--- a/examples/simple_html_example/pubspec.yaml
+++ b/examples/simple_html_example/pubspec.yaml
@@ -2,10 +2,10 @@ name: simple_html_example
 publish_to: none
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  angular: ^7.0.1
+  ngdart: ^7.1.0
   ngcomponents:
     path: ../../ngcomponents
   angular_gallery:

--- a/ngcomponents/CHANGELOG.md
+++ b/ngcomponents/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Change Log
 
+## 3.0.0-dev.1
+
+* [Breaking] Required Dart >= 2.17
+* [Breaking] Updated to use `ngdart`, `ngrouter` and `ngforms`
+
 ## 2.0.0-dev.1
 
-Nothing has changed compared to [2.0.0]. This version is published for the sole
-purpose of providing existing developers a convenient way to use on a null
-safety version of `angular_components` and to thoroughly test existing code that
-will be the basis for complete null safety migration.
+* Nothing has changed compared to [2.0.0]. This version is published for the sole purpose of providing existing developers a convenient way to use on a null safety version of `angular_components` and to thoroughly test existing code that will be the basis for complete null safety migration.
 
 ## 2.0.0
 
@@ -48,27 +50,33 @@ will be the basis for complete null safety migration.
   `package:angular_forms`.
 
 ## 0.14.0-alpha+1
+
 ### Component Updates
 
 #### Application Layout
+
 * Add `canClose` input the temporary drawer to prevent the drawer from toggling.
 
 #### Dynamic Component
+
 * Use type promotion instead of dynamic dispatch to update a `RendersValue`
   instance.
 * Change to "OnPush" change detection.
 
 #### Material Auto Suggest Input
+
 * Stop event propagation when key nav events are handled.
 * Update to work within components using `ChangeDetectionStrategy.OnPush`.
 
 #### Material Button
+
 * Add Sass mixins to change the padding on the internal button content, adjust
   vertical alignment, and reset `text-transform`.
 * Remove Sass mixin `button-text-capitalize()`.
 * Fix visibility in Microsoft Edge on Windows when using High Contrast mode.
 
 #### Material Datepicker
+
 * Add Sass mixins for margins around and between the next and previous buttons.
 * Increase the color ratio for the apply/cancel buttons.
 * Allow picking times using specified increments.
@@ -80,20 +88,24 @@ will be the basis for complete null safety migration.
 * Improved accessibility for presets.
 
 #### Material Dialog
+
 * Add Sass mixin for the footer margin.
 * Always keep a transparent scroll stroke to prevent dialog from shifting.
 
 #### Material Expansion Panel
+
 * Improve accessibility.
 * Accommodate contents taller than the screen size.
 
 #### Material Input
+
 * Make text size limits available to screen readers.
 * Change attribute `inputRole` to and input `role`.
 * Add a CSS class `.ltr` so input can set `direction: ltr` on the top section.
 * Add Sass mixin to adjust the location of floating label.
 
 #### Material Menu
+
 * Prevent screen readers from reading a non-collapsible label as "button".
 * Apply the same background color on focused and active items.
 * Update `icon` attribute to use a Dart boolean instead of a string `'true'`.
@@ -105,25 +117,30 @@ will be the basis for complete null safety migration.
 * Add a way to pass context to the `MenuItem` actions.
 
 #### Material Popup
+
 * Add `ariaLabel` input.
 * Encapsulate the popup class name.
 
 #### Material Select
+
 * Fix selected item visibility in Microsoft Edge on Windows when using High
   Contrast mode.
 * Add Sass mixins for adding ellipsis to overflowing item text and a custom
   outline.
 
 #### Material Slider
+
 * Support two sided sliders.
 
 #### Material Stepper
+
 * Add `yesText` input.
 * Add input to keep inactive steps in DOM.
 * Add partially complete state.
 * Update icon and index colors for improved a11y.
 
 #### Material Tab
+
 * Set tabbable tab to always be activeTab.
 * Improve `allow-text-wrap` Sass mixin.
 * Rename Sass mixin `allow-text-wrap` to `tab-text-wrap` and default
@@ -131,15 +148,18 @@ will be the basis for complete null safety migration.
 * Add Sass mixin to apply text transform.
 
 #### Material Tooltip
+
 * Fix deferred content within tooltip.
 * Add Sass mixin for paper tool tips with multiple sections.
 
 #### Material Tree
+
 * Add input to toggle selection of non-leaf nodes.
 
 ### Other Updates
 
 #### Miscellaneous
+
 * Remove `mat-icon-image()` in favor of `inline-image()`.
 * Add `subtract()` to Date model.
 * Migrate event handlers with multiple statements to component methods.
@@ -157,33 +177,41 @@ will be the basis for complete null safety migration.
 * Rename `palette.dart` to `material_chart_colors.dart`.
 
 ### Documentation
+
 * Minor documentation fixes.
 
 ## 0.14.0-alpha
+
 ### Component Updates
 
 #### Material Auto Suggest Input
+
 * Adding generic type to `factoryRenderers` in items.
 * Update blur event logic.
 * Add `inputAutocomplete` input.
 * Improve a11y with added aria controls.
 
 #### Material Checkbox
+
 * Add Sass mixin to remove all margins.
 
 #### Material Date Picker
+
 * Fix issue where given `dateFormat` was not used to decode the input value.
 * Apply `FocusableMixin`.
 * Modularize and deprecate `timeZoneAwareDatepickerProviders`.
 * Prevent wordwrap for the range title.
 
 #### Material Dialog
+
 * Add Sass mixin to justify footer content.
 
 #### Material Dropdown Select
+
 * Pass `aria-describedby` through to the dropdown button.
 
 #### Material Expansion Panel
+
 * Only auto focus a child, when the panel is expanded.
 * Only fire events and DOM changes on on-target TransitionEnd events.
 * Improve a11y by toggling content visibility when the panel expands or
@@ -191,57 +219,70 @@ will be the basis for complete null safety migration.
 * Add `focusOnOpen` input.
 
 #### Material Input
+
 * Add Sass mixin to change bottom section width and trailing text.
 * Add `inputAriaControls` input.
 
 #### Material Menu
+
 * Add `popupClass` and `buttonAriaLabelledBy` inputs.
 * Add Sass mixin to configure the background color of a selected menu item.
 
 #### Material Popup
+
 * Fix memory leak.
 
 #### Material Radio
+
 * Ensure changes are picked up by Angular's change detection.
 * Add Sass mixin to configure the content margin.
 * Fix issue where programmatic changes to the value model were not shown.
 
 #### Material Select
+
 * Adding generic type to `factoryRenderers` in items.
 * Add Sass mixins to configure item colors.
 
 #### Material Stepper
+
 * Fix an issue where when `activeStepIndex` is set to a value but the step state
   is not updated accordingly.
 
 #### Material Tab
+
 * Loop items and ignore up and down arrow key presses when focusing.
 
 #### Material Tooltip
+
 * Add Sass mixin to configure the max width of a tooltip.
 * Improve a11y with focus control.
 
 #### Material Tree
+
 * Properly apply `nested-material-tree-item-style` Sass mixin to nested items.
 * Introduce a `allowDeselectInHierarchy` configuration that allows clients to
   specify if a user should be allowed to deselect an option that they have
   already selected (by clicking on it again).
 
 #### Material Yes/No Buttons
+
 * Make `EnterAcceptsDirective` use key press instead of key up to align with
   button decorator.
 * Added `aria-describedby`.
 
 #### Scorecard
+
 * Only apply tabindex 0 to scorecards that are selectable.
 
 ### Other Updates
 
 #### Selection Model
+
 * Change `SelectionModel.isSingleSelect` from a field to an abstract getter.
 * Add a missing `super.dispose()` call to `_StreamSelectionOptions`
 
 #### Miscellaneous
+
 * Improve `OverlayService` singleton error message.
 * Modularize ruler bindings.
 * Fix a bug where scroll host would try to add events to a closed
@@ -265,44 +306,53 @@ will be the basis for complete null safety migration.
   links.
 
 ### Documentation
+
 * Minor documentation fixes.
 
 ## 0.13.0
+
 ### Component Updates
 
 #### Material Autosuggest Input
+
 * Toggle multi-select items with `<Space>` instead of `<Enter>`.
 * Make the pointer for the clear icon consistent with other buttons when
   disabled.
 
 #### Material Button
+
 * Apply media query to `_button_hover` mixin call so that we will skip hover for
   all touchscreens (only apply hover for media supporting hover).
 * Add Sass mixins to customize icon colors and left align button text.
 * Avoid double trigger of button with a space bar keypress.
 
 #### Material Checkbox
+
 * Use both label and content as aria label.
 * Add types to the outputs.
 
 #### Material Date Picker
+
 * Make the calendar component invisible to screen readers.
 * Add `selectDatePlaceHolderMsg`, `placeholderMsg`, and
   `dropdownButtonAriaLabel` inputs.
 
 #### Material Date Range Picker
+
 * Add `preferredPositions` input.
 * Improve handling of pt-BR date range formatting to remove repetitive "de"s
   when the endpoints fall into different years.
 * Make comparison toggle label clickable.
 
 #### Material Dialog
+
 * Add Sass mixin to customize font size.
 * Use header as default dialog label.
 * Mark current landmarks as `role="presentation"` to avoid unnecessary grouping.
 * Add missing modal visible output.
 
 #### Material Expansion Panel
+
 * Add missing modal visible output.
 * Allow header to have an outline, and control it with keyboard only focus.
 * Add aria-expanded to announce when it is opened/closed.
@@ -312,9 +362,11 @@ will be the basis for complete null safety migration.
   expansion panel opens.
 
 #### Material Icon
+
 * Add Sass mixin to customize svg icon size.
 
 #### Material Input
+
 * Update error message for negative percentage value to be "not negative"
   instead of "positive", because zero is allowed.
 * Ensure that `aria-disabled` is set for the input when the input is disabled.
@@ -330,6 +382,7 @@ will be the basis for complete null safety migration.
 * Pass down the aria-label for leading and trailing glyphs.
 
 #### Material Menu
+
 * Remove unnecessary escape key handling in MenuItemGroupsComponent.
 * Add in aria-label support into the items and groups.
 * Open dropdown when navigation keys are pressed.
@@ -340,9 +393,11 @@ will be the basis for complete null safety migration.
 * Add keyboard accessibility functionality for active item handling.
 
 #### Material Progress
+
 * Fix screen reader status messages.
 
 #### Material Popup
+
 * Add `autoDismissBlockers` input to block click events in certain elements from
   closing the popup.
 * Support defining custom boundaries around window viewport.
@@ -351,10 +406,12 @@ will be the basis for complete null safety migration.
 * Fix memory leaks.
 
 #### Material Stepper
+
 * Announce the current step via the screen reader.
 * Provide custom aria label for steps.
 
 #### Material Select
+
 * Fix issue where a keypress on selected item would re-open dropdown.
 * Remove `tabIndex` from items and let the dropdown control focus instead. Focus
   is now controlled by the dropdown itself.
@@ -368,35 +425,43 @@ will be the basis for complete null safety migration.
 * Update Sass mixin `dropdown-icon-spacing` to accept all four margins.
 
 #### Material Tab
+
 * Add Sass mixin to customize tab strip elevation.
 
 #### Material Toggle
+
 * Add focus effect.
 
 #### Material Tooltip
+
 * Remove `initAriaAttributes` for ink tooltips by default.
 * Fix hiding tooltip for `MaterialTooltipTargetDirective` when focusing inside
   of it.
 
 #### Material Tree
+
 * Add `allowParentSingleSelection` input.
 * Don't override state when `expandAll` hasn't been set.
 * Add component generics and pass type through to nodes.
 
 #### Material Yes/No Buttons
+
 * Add Sass mixin to make yes button raised and highlighted.
 * Add Sass mixin to make no button highlighted.
 
 #### Scorecard
+
 * Fix improper heading hierarchy.
 * Fixed scrolling when the average size of the cards is bigger than the client.
 
 #### Simple HTML Component
+
 * Add attribute `doNotVerifyUrlDestinations` to allow "normal" external URLs.
 
 ### Other Updates
 
 #### Selection Model
+
 * Allow `is NullSelectionModel` as a replacement for
   `== const SelectionModel.empty()`, necessary for typed selection models which
   can't use const.
@@ -405,6 +470,7 @@ will be the basis for complete null safety migration.
 * Add `isSingleSelect` field.
 
 #### Miscellaneous
+
 * Allow `HasTabIndex` to not set a `TabIndex`.
 * Fix a bug where sticky elements do not stack when sticky position is BOTTOM.
 * Use named providers instead of the soft deprecated provide(...) and
@@ -424,30 +490,37 @@ will be the basis for complete null safety migration.
 ### Component Updates
 
 #### Material Auto-Suggest Input
+
 * Disable clear icon when the input is disabled.
 * Hide an empty suggestion group.
 
 #### Material Button
+
 * Add Sass mixin to change the color of a disabled button.
 
 #### Material Card
+
 * Update elevation appearance to match spec.
 
 #### Material Chips
+
 * Allow setting a custom aria label for the delete button.
 * Fix issue that prevented removing chips while using JAWS screen reader.
 * Add Sass mixins for font-weight and padding.
 
 #### Material Datepicker
+
 * Remove `globalDateRangeBindings`.
 * Allow setting a custom aria label to the dropdown button.
 * Allow passing custom `DateFormat` from the `material-date-range-picker` to the
   `date-range-input`.
 
 #### Material Dialog
+
 * Allow setting a custom aria label and describe by.
 
 #### Material Expansion Panel
+
 * Ensure height calculations are completed after the main content is destroyed.
 * Fix keyboard controls to prevent focusing a hidden header button.
 * Allow setting a custom aria label to the panel.
@@ -459,10 +532,12 @@ will be the basis for complete null safety migration.
 * Move name ng-content above the input name and description.
 
 #### Material Icon
+
 * Correctly stretch SVG icon.
 * Remove aria label from the icon.
 
 #### Material Input
+
 * Add Sass mixin for label text vertical-align.
 * `'percent'` is an invalid type attribute, `'text'` instead.
 * If the multi-line input is not currently in the DOM listen to DOM updates
@@ -474,9 +549,11 @@ will be the basis for complete null safety migration.
 * Fix focus behavior in disabled state.
 
 #### Material List
+
 * Change the default roles to `list` and `listitem`.
 
 #### Material Menu
+
 * Create standalone menu item affix components.
 * Load standalone menu item affix components via `DynamicComponent` instead of
   using `NgIf`s.
@@ -484,16 +561,20 @@ will be the basis for complete null safety migration.
 * Create `MenuItemMixin`.
 
 #### Material Month Picker
+
 * Re-render highlights when view is reset.
 
 #### Material Popup
+
 * Move the overlay focus placeholder elements inside of Material Popup.
 * Enable `OnPush` change detection.
 
 #### Material Ripple
+
 * Remove ripple elements when component is destroyed.
 
 #### Material Select
+
 * Support custom aria handling for each list item in dropdown.
 * Support `OnPush` change detection.
 * Revert change that attempted to fix strange behavior when mixing keyboard and
@@ -502,33 +583,41 @@ will be the basis for complete null safety migration.
 * Add Sass mixin to customize dropdown item selected background color.
 
 #### Material Tab
+
 * Add Sass mixin to make the tab contents `display: block`.
 
 #### Material Time Picker
+
 * Fix regression where time cannot be set by user a programmatic change.
 
 #### Material Tooltip
+
 * `initPopupAriaAttributes` is now passed through to all the tooltip variations.
 * Restore any previously defined `aria-describedby` value, after popup closes.
 * Add Sass mixin to set `word-break`.
 * Fix nested tooltip targets preventing tooltips from staying open when hovered.
 
 #### Material Tree
+
 * Add ability to specify a label renderer for dropdown button text.
 * Add ability to style items in the tree dropdown.
 
 #### Material Yes/No Buttons
+
 * Add optional ARIA label inputs.
 * Add Sass mixin to remove the `margin-left`.
 * Add autofocus functionality for use in confirmation dialogs.
 
 #### Scorecard
+
 * Vertically align the change glyph to the middle.
 
 #### Simple HTML Component
+
 * Allow 'class' attribute for all elements.
 
 ### Miscellaneous
+
 * Add home/end key modifiers to focus_list to focus the first or last value.
 * Remove `$mat-gray` as an alias for `$mat-grey` in Sass mixins.
 * Add `shouldFilterEmpty` parameter to `StringSelectionOptions` to return empty
@@ -543,22 +632,26 @@ will be the basis for complete null safety migration.
   default values.
 
 ### Documentation
+
 * Minor docs fixes.
 
 ## 0.11.0
 
 ### New Component
+
 * Simple HTML Component.
 
 ### Component Updates
 
 #### Material Chips
+
 * Add a focused style to delete icon.
 * Remove default value from `$max-chip-width` in the `material-chip-max-width`
   Sass mixin.
 * Remove `material-chips-margin` Sass mixin.
 
 #### Material Date Range Picker
+
 * Make dropdown not tabbable so it can be opened using the top level button
   decorator.
 * Add NextNDaysFromToday class.
@@ -567,18 +660,22 @@ will be the basis for complete null safety migration.
 * Make intl messages `final`.
 
 #### Material Dialog
+
 * Fix size of full screen dialog.
 * Close parent modal on escape key by default.
 
 #### Material Icon
+
 * Add `MaterialIconToggleDirective` to allow for an icon with two states.
 
 #### Material Input
+
 * Update the integer error message per Editorial feedback.
 * Add Sass mixin for changing the color of the counter.
 * Fix a11y when there is a `labeledby` id and a aria label specified.
 
 #### Material Menu
+
 * Add a drop-in replacement for `secondaryIcon` - `itemSuffix` that removes the
   boilerplate of creating an observable list for a single element.
 * Automatically expand a collapsed category when keyboard navigating to a child
@@ -591,9 +688,11 @@ will be the basis for complete null safety migration.
 * Fix focus target when pressing Up Arrow key.
 
 #### Material Popup
+
 * Correctly restore focus in nested popups.
 
 #### Material Select
+
 * Add type parameters on `BaseDropdownSelectValueAccessor` and subclasses.
 * Set max-width to 100% on `dynamic-item`.
 * Removing Sass mixin for setting the width of the container element in
@@ -606,13 +705,16 @@ will be the basis for complete null safety migration.
 * Fix the type of `itemRenderer` in `MaterialDropdownSelectComponent`.
 
 #### Material Tabs
+
 * Make default width of `tab-content` to 100%.
 
 #### Material Tooltip
+
 * Improve a11y and keyboard navigation.
 * Fix removing describe-by.
 
 #### Modal/Overlay
+
 * Add ability to create an accessible overlay container for clients that
   currently provide custom overlay container.
 * Fix selector of `PopupSizeProviderDirective`.
@@ -622,6 +724,7 @@ will be the basis for complete null safety migration.
   element.
 
 ### Miscellaneous
+
 * Improve error message when selection type is wrong in `SelectionInputAdapter`.
 * Add `primaryStyle` to `StyleFormatter`.
 * Refactor the keyboard only focus indicator so that when an element is focused
@@ -633,6 +736,7 @@ will be the basis for complete null safety migration.
 * Add `FocusIndicatorController` for use in debug environments.
 
 ### Documentation
+
 * Minor docs fixes.
 
 ## 0.10.1
@@ -640,6 +744,7 @@ will be the basis for complete null safety migration.
 ### Component Updates
 
 #### Material Chips
+
 * Improve support for generics.
 * Stop setting popup attributes as those attributes are set on the input
   directly.
@@ -648,58 +753,73 @@ will be the basis for complete null safety migration.
 * Add Sass mixin to allow text wrapping.
 
 #### Material Date Picker
+
 * Use `PopupSizeProvider` to control the height of the picker.
 * Add `rangeFormatter` input to the range picker.
 
 #### Material Expansion Panel
+
 * Improve accessibility.
 * Smooth expansion/collapse animations when headers are hidden.
 
 #### Material Icon
+
 * Add Sass mixin to use an SVG for an icon instead of the standard font icons.
 
 #### Material Input
+
 * Add Sass mixins to disable wrapping for hint text and hide leading and
   trailing text.
 * Fix `MaterialPercentInputDirective` for LTR languages with leading % symbol.
 * Fix inconsistent margins in Safari browser.
 
 #### Material Menu
+
 * Add ability to provide extra label annotations for menu items.
 
 #### Material Select
+
 * Add Sass mixins to restrict item width, font size, line height, and padding.
 * Added generics support.
 * Add `activateFirstOption` input.
 
 #### Material Slider
+
 * No longer focusable when disabled.
 
 #### Material Stepper
+
 * Ensure items that can't be selected also can't be tabbed to.
 
 #### Material Tab
+
 * Add Sass mixin for a shadow below the tab strip.
 
 #### Material Tree
+
 * Add a dynamic content to accommodate custom elements.
 
 #### Material Toggle
+
 * Update the theme Sass mixin to include a grey color when the toggle is
   disabled.
 
 #### Material Tooltip
+
 * Add Sass mixins to control padding, and max height.
 
 #### Material Yes/No Buttons
+
 * Allow No button to be disabled.
 
 #### Modal/Overlay
+
 * Add null guard check to event.
 * A11y improvements.
 * Attempt to restore focus when modal closes.
 
 ### Miscellaneous
+
 * Update MDC Web styles to v0.40.0.
 * Improved support for generics in `HighlightAssistant`.
 * Handle unsupported `WheelEvent.deltaX` in scroll host.
@@ -707,6 +827,7 @@ will be the basis for complete null safety migration.
 * Allow dropdown components to contain an `auto_focus` directive.
 
 ### Documentation
+
 * Minor docs fixes.
 
 ## 0.10.0
@@ -714,6 +835,7 @@ will be the basis for complete null safety migration.
 ### Component Updates
 
 #### Material Auto Suggest Input
+
 * Rename `shouldClearOnSelection` to `shouldClearInputOnSelection`.
 * Improve keyboard navigation after mouse interactions in the popup.
 * Only allow deselection via in multi-selection mode in material auto suggest
@@ -723,22 +845,27 @@ will be the basis for complete null safety migration.
 * Update to support generics.
 
 #### Material Button
+
 * Mark certain fields as `visibleForTemplate` and drop the copied value where
   not needed.
 
 #### Material Chips
+
 * Add Sass mixins to adjust border and font size of a single chip and border
   padding, and background color, border, and padding of a set of chips.
 
 #### Material Expansion Panel
+
 * Wrap the buttons in a `defferredContent` directive. This is to help
   accessibility and have those buttons not be available for screen readers.
 
 #### Material Input
+
 * Fix bug in `MaterialNumberValueAccessor` where null value won't clear previous
   input.
 
 #### Material Dropdown Select
+
 * Provide the simplified selection and options inputs. Pull the common logic
   into SelectionInputAdapter mixin class.
 * Migrate `ComponentRenderer` to `FactoryRenderer`.
@@ -746,22 +873,27 @@ will be the basis for complete null safety migration.
 * Highlight disabled items when activated via keyboard.
 
 #### Material Menu
+
 * Add a secondary-label field. The appearance of this label is subject to minor
   changes in the near future as the UX is still experimental.
 * Properly use the sub-menu's width, not the parent menu's width, to determine
   the width of the menu.
 
 #### Material Radio
+
 * Tighten down the public API surface of the radio component by marking many of
   them as `visibleForTemplate`.
 
 #### Material Select Searchbox
+
 * Add in null pointer protection when input is set without a filterable.
 
 #### Modal/Overlay
+
 * Enable useMultiModalDismissal by default.
 
 ### Miscellaneous
+
 * Use typed provider for location providers.
 * Also corrected the type signature of `runOutsideAngular`, which in turn may
   enable hint-level warnings by the analyzer. Users may be impacted if they fail
@@ -772,6 +904,7 @@ will be the basis for complete null safety migration.
 * Trigger the sticky controller sync on `scrollToPosition` calls.
 
 ### Documentation
+
 * Add new readme for Material Dropdown Select.
 * Minor docs fixes.
 
@@ -780,6 +913,7 @@ will be the basis for complete null safety migration.
 ### Component Updates
 
 #### Material Auto Suggest Input
+
 * Implement `HasDisabled`.
 * Allow `selection` input to take selected value for single selection in
   addition to `SelectionModel`.
@@ -787,18 +921,22 @@ will be the basis for complete null safety migration.
 * Add `shouldClearSelectionOnInput` input.
 
 #### Material Button
+
 * Remove unused `hover-color` argument from button color Sass mixins.
 
 #### Material Datepicker
+
 * Add Sass mixins for rendering the range title to the left of the dropdown
   component and for removing some padding to save vertical space.
 * Harden `DatepickerComparison.comparesTo()` against nulls.
 
 #### Material Expansion Panel
+
 * Add transition to save/cancel collapse.
 * Add Sass mixin for custom `box-shadow`.
 
 #### Material Input
+
 * Add Sass mixin to set the bottom section margins.
 * Allow `MaterialPercentInputDirective` to follow `NumberFormat` specification
   for percent.
@@ -806,21 +944,26 @@ will be the basis for complete null safety migration.
   `SelectionOptions`.
 
 #### Material Menu
+
 * Remove Sass mixin `material-fab-menu-icon-size`.
 
 #### Material Tooltip
+
 * Change the ink tooltip stay open if the mouse is currently in it's bounds.
 
 #### Material Tree
+
 * Allows dropdown component to accept custom popup positions.
 * Fix off-center alignment issue between radio button and text in
   `MaterialTreeGroupFlatRadioComponent`.
 
 #### Scorecard
+
 * Expose `ScorecardBarDirective` so it can be resued by other card bar
   implementations.
 
 ### Miscellaneous
+
 * Improvements to `StickyController` for the __single-stickyKey case__: Add
   `enableSmoothPushing` setting, and partially support stickyKey'd elements of
   differing heights.
@@ -829,6 +972,7 @@ will be the basis for complete null safety migration.
 * Fix `unawaited_futures` lint warnings by adding missing `await`s.
 
 ### Documentation
+
 * Add new readme for Material Auto-suggest Input.
 * Minor docs fixes.
 
@@ -837,30 +981,37 @@ will be the basis for complete null safety migration.
 ### Component Updates
 
 #### Material Date Range Picker
+
 * Add an option to disable maintaining the length of the date range when
   clicking on the calendar to move the start date.
 
 #### Material Expansion Panel
+
 * Add Sass mixin for border radius.
 * Only register immediate child panels in a panel set.
 * Add listener for expand change to fix bug where an expansion panel set would
   not recognize a programmatically pre-expanded panel.
 
 #### Material Select
+
 * Add Sass mixin for the selected item color.
 
 #### Material Stepper
+
 * Add Sass mixins for the step name color.
 
 #### Material Toolip
+
 * Add Sass mixin to set the card tooltip max width.
 * Add an icon attribute to specify any icon by name.
 * Add positioning options on icon tooltip.
 
 #### Selection Options
+
 * Add interface to segment options into option groups.
 
 ### Miscellaneous
+
 * Fix `ActiveItemDirective`'s scroll into view functionality in popups and
   modals.
 * Add `ObservableView.firstNonNull` and `ObservableView.nonNullValues`.
@@ -869,6 +1020,7 @@ will be the basis for complete null safety migration.
 * Fix default line-height values to match MDC versions.
 
 ### Documentation
+
 * Minor doc fixes.
 * Cleanup some docs for with optional new/const.
 
@@ -882,6 +1034,7 @@ will be the basis for complete null safety migration.
 > more details.
 
 ### Breaking Changes
+
 * Remove `is SelectableWithComposition`.
 * Remove `SelectableChangeNotifier` and deprecate `SelectableWithComposition`
   with the intention to remove. They are widely unused, complicated the
@@ -889,6 +1042,7 @@ will be the basis for complete null safety migration.
 * `ActiveItemMixin` has been removed in favor of the new `ActiveItemDirective`.
 
 ### New Components
+
 * Material Card styling
   * Provided by the Google material team also known as mdc-web. The styles
     included in this package are provided as a convenience to users in the Dart
@@ -902,6 +1056,7 @@ will be the basis for complete null safety migration.
 ### Component Updates
 
 #### App Layout
+
 * Update Material Header `z-index` to 1.
 * Add support for 0 or 2 drawers.
 * Add mixin for permanent/persistent drawers and fix mixin for temporary
@@ -911,9 +1066,11 @@ will be the basis for complete null safety migration.
   contents.
 
 #### Button Decorator
+
 * Allow role to be customized.
 
 #### Material Auto-Suggest Input
+
 * Improve keyboard navigation behavior.
 * Prevent marking itself as dirty when it receives initial form value.
 * Add aria label to close button.
@@ -928,6 +1085,7 @@ will be the basis for complete null safety migration.
 * Protect against method being called after it is destroyed.
 
 #### Material Button
+
 * Update elevation on buttons that have focus.
 * Remove styles for vertically aligned icon with text buttons.
 * Update size and position of text labels for icon buttons.
@@ -944,6 +1102,7 @@ will be the basis for complete null safety migration.
 * Update mixin names and fix to prevent styles leaking outside of the component.
 
 #### Material Checkbox
+
 * Remove deprecated `material-checkbox-theme` mixin.
 * Add `material-checkbox-color` mixin and deprecate `material-checkbox-theme`.
 * Change `include-in-checkbox` default to false in `checkbox-color` mixin to
@@ -960,10 +1119,12 @@ will be the basis for complete null safety migration.
   opacity of the checkbox.
 
 #### Material Chips
+
 * Allow overriding left-icon-color.
 * Update margin on dense theme.
 
 #### Material Dialog
+
 * Fix bug with full screen dialogs.
 * Fix bug where a disposable could be added to its disposer after it had already
   been destroyed.
@@ -974,12 +1135,15 @@ will be the basis for complete null safety migration.
 * Remove `preserveWhitespace: false`.
 
 #### Material Dropdown Select
+
 * Add back `keyboardOnlyFocusIndicator` to dropdown items.
 
 #### Material FAB
+
 * Update shadow styles.
 
 #### Material Icon
+
 * Add aria label and use them for trailing/leading icons of Material Input.
 * Add mixin for font weight.
 * Update mixins to allow overriding elements which have the size attribute set.
@@ -989,6 +1153,7 @@ will be the basis for complete null safety migration.
 * Flip half_star icon when in RTL.
 
 #### Material Input
+
 * Remove element used for resizing if the textarea does not need to be resized.
 * Added an `aria-labelledby` attribute.
 * Add mixin to adjust padding for multi-line inputs.
@@ -1027,6 +1192,7 @@ will be the basis for complete null safety migration.
 * Fix unexpected `)` in selector for `MaterialInputDefaultValueAccessor`.
 
 #### Material Expansionpanel
+
 * Do not change background color on focus or hover when disabled.
 * Fix issue where header could extend beyond the max-width of its container.
 * Add a mixin for no borders.
@@ -1046,6 +1212,7 @@ will be the basis for complete null safety migration.
 * Remove `preserveWhitespace: false`.
 
 #### Material Popup
+
 * Change `<main>` html tag to a `<div>`. HTML5 states there should only be one
   main tag per application.
 * Automatically restore focus on the popup source element when user tabs out.
@@ -1059,10 +1226,12 @@ will be the basis for complete null safety migration.
   popups.
 
 #### Material Progress
+
 * Add mixin for taller bars with rounded ends.
 * Fall back to the non-optimized animation if the width is 0 after view init.
 
 #### Material Radio
+
 * Remove `material-radio-theme` mixin.
 * Add `role` attribute.
 * Add `material-radio-color` mixin and deprecate `material-radio-theme`.
@@ -1073,10 +1242,12 @@ will be the basis for complete null safety migration.
 * Update disabled color to match spec.
 
 #### Material Ripple
+
 * Allow the ripple to be created programmatically.
 * Update animation to match new spec.
 
 #### Material Select
+
 * Update ARIA `labelledby` for improved a11y.
 * Update to `activedescendant` ARIA pattern for a11y.
 * Ensure button text displays correctly when an error message shows below it.
@@ -1111,9 +1282,11 @@ will be the basis for complete null safety migration.
 * Cleanup unused styles.
 
 #### Material Spinner
+
 * Add mixin to adjust the stroke width.
 
 #### Material Tabs
+
 * General cleanup: remove unneeded directive, use absolute imports, and fix
   spelling error.
 * Add support for `disabled` attribute.
@@ -1122,11 +1295,13 @@ will be the basis for complete null safety migration.
 * Increase space between labels.
 
 #### Material Toggle
+
 * Implement `ControlValueAccessor`.
 * Fix `aria-pressed` state.
 * Add mixin to display label on the right.
 
 #### Material Tooltip
+
 * Fix comment which was using deprecated `ElementRef`.
 * Allow paper tooltip CSS to be customizable.
 * Allow `'error_outline'` as a valid icon.
@@ -1138,6 +1313,7 @@ will be the basis for complete null safety migration.
   that the value isn't added in the middle of a change detection loop.
 
 #### Material Tree
+
 * Add `visibleChange` output stream to `MaterialTreeDropdownComponent`.
 * Use item identity to remember expanded state.
 * Add a `shouldExpandAllWhenFiltered` input.
@@ -1153,17 +1329,20 @@ will be the basis for complete null safety migration.
 * Clear filter inside the popup when `MaterialTreeDropdown` closes.
 
 #### Material Yes/No Buttons
+
 * Fix bug where text color was not applying to highlighted/raised yes button.
 * Fix no button to not override disabled text label color.
 * Remove `Visibility.all`.
 * Update mixins to use CSS shimming.
 
 #### Reorder List
+
 * Add ability to specify a handle element in a complex component.
 * Calculate the full height/width of the elements.
 * Restrict when a dragged item's target index is incremented or decremented.
 
 #### Scorecard
+
 * Add mixin for changing the display to flex.
 * Remove the `:host` from the padding mixin so it is not required to be used at
   the top level.
@@ -1174,7 +1353,9 @@ will be the basis for complete null safety migration.
 * Add a tooltip field.
 
 ### Other Updates
+
 #### Selection Model
+
 * Add `is{Selectable|Disabled|Hidden}In()`, `getOptionIn()` and, `filterWhere()`
   as static helpers to `Selectable`.
 * Add empty, single, and multi constructors.
@@ -1189,6 +1370,7 @@ will be the basis for complete null safety migration.
 * Use generic type for table selection model `SelectableGetter`.
 
 #### Modal/Overlay
+
 * Add attribute on `PopupSourceDirective` to decide whether to set the popup
   related aria attributes.
 * Ensure parent modal is shown when the current modal is destroyed.
@@ -1202,6 +1384,7 @@ will be the basis for complete null safety migration.
 * Add support for minimum width and height to `PopupSizeProvider`.
 
 #### Miscellaneous
+
 * Make `DomService` run callbacks in the correct zone.
 * Fix bug in `DomTreeIterator.moveNext()` where it was using equality instead of
   assignment.
@@ -1275,6 +1458,7 @@ will be the basis for complete null safety migration.
   remove `.scss` files from the output.
 
 #### Angular API Updates
+
 * Migrate from `host` to new `@HostListener` and `@HostBinding` syntax.
 * Migrate from `ElementRef` to `Element` or `HtmlElement`.
 * Set `visibility` to `Visibility.all` on Directives that are expected to
@@ -1284,6 +1468,7 @@ will be the basis for complete null safety migration.
   when components manage spacing around themselves and have been validated.
 
 #### Dart 2 Updates
+
 * Fixes for Dart 2 compile-time and runtime errors.
 * Application of `dartfmt --fix`.
 * Migrate from `Stream<Null>` to `Stream<void>`.
@@ -1294,207 +1479,210 @@ will be the basis for complete null safety migration.
 * Fix Dart2 runtime cast failures and other Dart 2 fixes.
 
 #### Documentation
+
 * General documentation cleanup for `@Input`s and `@Output`s. Improves
   documentation generated by the component gallery.
 
 ## 0.8.0
 
- * Move entry points to all components out of the lib/src/ directory.
- * Remove all precompiled .css files.
- * Update all import statements in .scss files to use dart style package
+* Move entry points to all components out of the lib/src/ directory.
+* Remove all precompiled .css files.
+* Update all import statements in .scss files to use dart style package
    imports.
- * Add dependency on sass_builder package to compile .css files.
+* Add dependency on sass_builder package to compile .css files.
 
 ## 0.7.1
 
- * Add Material Auto Suggest Input component.
- * Material Checkbox: Fix disabled state to match material-spec which is a light
+* Add Material Auto Suggest Input component.
+* Material Checkbox: Fix disabled state to match material-spec which is a light
    grey not a certain opacity of the checkbox.
- * Material Chips: Add high density mixin.
- * Material Input:
-   * Add selectAll function for calling the underlying input element's select
+* Material Chips: Add high density mixin.
+* Material Input:
+  * Add selectAll function for calling the underlying input element's select
      method that focuses the input and selects all its content.
-   * Add ability to update the data on a change instead of keypress or blur for
+  * Add ability to update the data on a change instead of keypress or blur for
      the standard Material Input.
-   * Remove error color from floating label to conform to material spec.
- * Material Popup:
-   * Fix mismatch between the variable used as a reference point for
+  * Remove error color from floating label to conform to material spec.
+* Material Popup:
+  * Fix mismatch between the variable used as a reference point for
      repositioning the popup and the variable used to initially set the popup's
      position. This caused issues when the tab was in the background because
      these variables could have changed significantly before the next animation
      frame fired (since requestAnimationFrame is throttled when the tab isn't
      visible).
-   * Use `_sourceDimensions` instead of `layoutRects[1]` to take overlay
+  * Use `_sourceDimensions` instead of `layoutRects[1]` to take overlay
      container offset into account. Using popupSourceLayoutStream directly
      caused issues when the .acx-overlay-container offset was not (0, 0).
- * Material Select: Fix orientation when groups are used.
- * Scorecard:
-   * Fix styling for extra-big cards.
-   * Fix to allow selectable scorecards in a "custom" scoreboard.
-   * Add a tooltip field enabling scenarios where more information about the
+* Material Select: Fix orientation when groups are used.
+* Scorecard:
+  * Fix styling for extra-big cards.
+  * Fix to allow selectable scorecards in a "custom" scoreboard.
+  * Add a tooltip field enabling scenarios where more information about the
      value can be displayed.
- * Theme: Prepare dark theme for upcoming Visibility.None change.
- * Cleanup unused fields.
- * Update default material scrollbar width to 8px. This is easier to use with a
+* Theme: Prepare dark theme for upcoming Visibility.None change.
+* Cleanup unused fields.
+* Update default material scrollbar width to 8px. This is easier to use with a
    mouse or touch input compared to the previous default of 4px.
- * Cleanup unused styles and reorganize `.scss` files.
- * Remove link hover style.
- * Migrate uses of `ElementRef` to `Element`.
- * Remove `visibility: Visibility.none` from all components since compatibility
+* Cleanup unused styles and reorganize `.scss` files.
+* Remove link hover style.
+* Migrate uses of `ElementRef` to `Element`.
+* Remove `visibility: Visibility.none` from all components since compatibility
    is not yet fully supported. Will be added in an upcoming release.
- * Update documentation.
+* Update documentation.
 
 ## 0.7.0
 
- * Material Button: Add raised mixin so that buttons can be made to be raised
+* Material Button: Add raised mixin so that buttons can be made to be raised
    without using the attribute.
- * Material Expansionpanel: Add header minimum height mixin.
- * Material Input: Add support for custom number formatters.
- * Material Popup:
-   * Remove `PopupEvent` and reduce asynchrony.
-   * Update PopupSizeProvider max-width/height once the popup has been
+* Material Expansionpanel: Add header minimum height mixin.
+* Material Input: Add support for custom number formatters.
+* Material Popup:
+  * Remove `PopupEvent` and reduce asynchrony.
+  * Update PopupSizeProvider max-width/height once the popup has been
      positioned.
-   * Remove unused `contenWidth` and `contentHeight`.
- * Material Radio: Avoid selecting null when the new selected value is not found
+  * Remove unused `contenWidth` and `contentHeight`.
+* Material Radio: Avoid selecting null when the new selected value is not found
    in the options.
- * Material Tab:
-   * Fix logic for the active tab when tabs themselves are changed. Before logic
+* Material Tab:
+  * Fix logic for the active tab when tabs themselves are changed. Before logic
      was activating/deactivating based on index, but when tabs change the index
      has probably changed.
-   * Make mixin to allow text wrapping.
- * Material Tree:
-   * Fix bug where state of material tree option cannot be changed by selection
+  * Make mixin to allow text wrapping.
+* Material Tree:
+  * Fix bug where state of material tree option cannot be changed by selection
      model.
-   * Fix bug where tree_dropdown_select did not auto open correctly using focus.
- * Scorecard: Update colors to match material spec.
- * Deprecate obsolete box-sizing style mixin.
- * Add link color styles and mixin.
- * Add typography style mixins.
- * Set preserveWhitespace: true in preparation for angular flipping the default
+  * Fix bug where tree_dropdown_select did not auto open correctly using focus.
+* Scorecard: Update colors to match material spec.
+* Deprecate obsolete box-sizing style mixin.
+* Add link color styles and mixin.
+* Add typography style mixins.
+* Set preserveWhitespace: true in preparation for angular flipping the default
    to false.
- * Make functional directive name lowercase to conform with Dart style guide.
- * Replaces deprecated inputs and outputs with inline annotations.
- * Update visibility for provider resolution fix.
- * Update documentation.
+* Make functional directive name lowercase to conform with Dart style guide.
+* Replaces deprecated inputs and outputs with inline annotations.
+* Update visibility for provider resolution fix.
+* Update documentation.
 
 ### Known Issues
- * Warnings are present when building with dart2js. Specifically:
+
+* Warnings are present when building with dart2js. Specifically:
    _Method type variables are treated as `dynamic` in `as` expressions._
 
 ## 0.6.0
 
- * Update dependency to angular: ^4.0.0.
- * Update SDK dependencies.
- * Add Material Select Searchbox component.
- * Add Application Layout styles and directives.
- * Add Material Icon.
-   * Deprecate `GlyphComponent` in favor of `MaterialIconComponent`.
- * App Layout: Fix margins for header icons/links.
- * Dynamic Component: Add ability to use `ComponentFactory` instead of a `Type`.
- * Material Button: Refactor raised styling so it can be used in a mixin.
- * Material Checkbox:
-   * Add ability to make readonly.
-   * Add mixin for checkbox with no left margin.
- * Material Chips: Add ability to specify background color for left icon.
- * Material Dialog:
-   * Support a minimum height.
-   * Fix header mixin.
- * Material Expansionpanel:
-   * Add high density mixin.
-   * Add mixin to allow changes to panels without affecting nested panels.
- * Material Icon: Add back and forward arrows to the list of flipped icons.
- * Material Input:
-   * Add support for material dark theme.
-   * Fix disabled color.
-   * Add leading text color mixin.
-   * Make local required errors to make controls invalid even when the control
+* Update dependency to angular: ^4.0.0.
+* Update SDK dependencies.
+* Add Material Select Searchbox component.
+* Add Application Layout styles and directives.
+* Add Material Icon.
+  * Deprecate `GlyphComponent` in favor of `MaterialIconComponent`.
+* App Layout: Fix margins for header icons/links.
+* Dynamic Component: Add ability to use `ComponentFactory` instead of a `Type`.
+* Material Button: Refactor raised styling so it can be used in a mixin.
+* Material Checkbox:
+  * Add ability to make readonly.
+  * Add mixin for checkbox with no left margin.
+* Material Chips: Add ability to specify background color for left icon.
+* Material Dialog:
+  * Support a minimum height.
+  * Fix header mixin.
+* Material Expansionpanel:
+  * Add high density mixin.
+  * Add mixin to allow changes to panels without affecting nested panels.
+* Material Icon: Add back and forward arrows to the list of flipped icons.
+* Material Input:
+  * Add support for material dark theme.
+  * Fix disabled color.
+  * Add leading text color mixin.
+  * Make local required errors to make controls invalid even when the control
      has not been interacted with.
-   * Add upper and lower bounds validators.
-   * Re-calculate text length when custom character counter is set.
-   * Prevent mirror-text overflow in multiline material input.
-   * Remove unnecessary selector argument from mixins.
- * Material Popup:
-   * Constrain popups to the viewport if both `enforceSpaceConstraints` and
+  * Add upper and lower bounds validators.
+  * Re-calculate text length when custom character counter is set.
+  * Prevent mirror-text overflow in multiline material input.
+  * Remove unnecessary selector argument from mixins.
+* Material Popup:
+  * Constrain popups to the viewport if both `enforceSpaceConstraints` and
      `overlayRepositionLoop` are enabled.
-   * Create the material-popup view synchronously.
-   * Remove `animationComplete` event.
-   * Integrate with Angular CSS shimming and remove `shadowCssClass`.
-   * Material design scrollbars by default (instead of the native scrollbars).
-   * Add ARIA attributes.
-   * Add an option to reposition visible popups every frame with
+  * Create the material-popup view synchronously.
+  * Remove `animationComplete` event.
+  * Integrate with Angular CSS shimming and remove `shadowCssClass`.
+  * Material design scrollbars by default (instead of the native scrollbars).
+  * Add ARIA attributes.
+  * Add an option to reposition visible popups every frame with
      `trackLayoutChanges`.
-   * Merge laminate/components/popup into Material Popup.
-   * Only set content removed if the popup is still not visible when the timer
+  * Merge laminate/components/popup into Material Popup.
+  * Only set content removed if the popup is still not visible when the timer
      is finished.
- * Material Radio:
-   * Add mixin for radio button with no left margin.
-   * Fix mixin to respect disabled status when a theme is applied.
- * Material Select:
-   * Fix selectable menu item property functionality.
-   * Allow dropdown to display an error while it's closed.
-   * Fix `MaterialSelectItemComponent` to not cache the label.
-   * Add input to material-dropdown-select to define custom a renderer for group
+* Material Radio:
+  * Add mixin for radio button with no left margin.
+  * Fix mixin to respect disabled status when a theme is applied.
+* Material Select:
+  * Fix selectable menu item property functionality.
+  * Allow dropdown to display an error while it's closed.
+  * Fix `MaterialSelectItemComponent` to not cache the label.
+  * Add input to material-dropdown-select to define custom a renderer for group
      labels.
-   * Fix checkbox display handling and label padding in dropdown.
- * Material Toggle: Set the attribute instead of the property to fix a bug with
+  * Fix checkbox display handling and label padding in dropdown.
+* Material Toggle: Set the attribute instead of the property to fix a bug with
    incorrect type, and not setting the right property.
- * Material Tooltips: Add ARIA attributes.
- * Material Tree:
-   * Update positioning options and borders.
-   * Add optional row separator borders.
-   * Fix dropdown closing on toggle issue.
-   * Added shift selection/deselection.
-   * Fix glyphs always shown expanded when `expandAll = true`.
-   * Add ability to preserve expansion state.
-   * Fix indentation of first child group.
-   * Add input `showDisabledCheckboxes`.
-   * Add a max-height mixin.
- * Material Yes/No Buttons: Add dense style.
- * Reorder List:
-   * Update to recommended syntax for ngFor.
-   * Migrate from ManagedZone to NgZone.
- * Scorecard:
-   * Update tab index to prevent scroll errors when going through
+* Material Tooltips: Add ARIA attributes.
+* Material Tree:
+  * Update positioning options and borders.
+  * Add optional row separator borders.
+  * Fix dropdown closing on toggle issue.
+  * Added shift selection/deselection.
+  * Fix glyphs always shown expanded when `expandAll = true`.
+  * Add ability to preserve expansion state.
+  * Fix indentation of first child group.
+  * Add input `showDisabledCheckboxes`.
+  * Add a max-height mixin.
+* Material Yes/No Buttons: Add dense style.
+* Reorder List:
+  * Update to recommended syntax for ngFor.
+  * Migrate from ManagedZone to NgZone.
+* Scorecard:
+  * Update tab index to prevent scroll errors when going through
      buttons with tabs.
-   * Replace deprecated Glyph with Material Icon.
-   * Invoke inherited click handler from derived click handler.
- * Selection Models:
-   * Add deselect all option.
-   * Add a limited filtering model.
-   * Fix `selectAll` to only trigger a selection change event for the values
+  * Replace deprecated Glyph with Material Icon.
+  * Invoke inherited click handler from derived click handler.
+* Selection Models:
+  * Add deselect all option.
+  * Add a limited filtering model.
+  * Fix `selectAll` to only trigger a selection change event for the values
      that were added.
-   * Add comparator as optional param to tree selection options for custom
+  * Add comparator as optional param to tree selection options for custom
      sorting.
- * Avoid adding placeholder for deferred content if the element is detached.
- * Add new color utils.
- * Update animations to new Material specs.
- * Migrate uses of `GlyphComponent` to `MaterialIconComponent`.
- * Migrate uses of `ElementRef` to `Element`.
- * Remove duplicate PopupSourceDirective.
- * Remove deprecated popup `matchSourceWidth` options.
- * Add missing `MaterialIconComponent`, `MaterialPersistentDrawerDirective`,
+* Avoid adding placeholder for deferred content if the element is detached.
+* Add new color utils.
+* Update animations to new Material specs.
+* Migrate uses of `GlyphComponent` to `MaterialIconComponent`.
+* Migrate uses of `ElementRef` to `Element`.
+* Remove duplicate PopupSourceDirective.
+* Remove deprecated popup `matchSourceWidth` options.
+* Add missing `MaterialIconComponent`, `MaterialPersistentDrawerDirective`,
    `MaterialTemporaryDrawerDirective`, and `MaterialSelectSearchboxComponent` to
    `materialDirectives`.
- * Improve performance of `TreeSelectionOptions` constructor from O(n^2) to O(n)
+* Improve performance of `TreeSelectionOptions` constructor from O(n^2) to O(n)
     in the size of `listOfOptions`.
- * Change DisplayNameRenderDirective to a functional directive.
- * Deprecate LazyEventEmitter and migrate uses to the StreamController model.
- * Additional styling cleanup to support `ng-deep`.
- * Reduce visibility of common directives/components for smaller code size and
+* Change DisplayNameRenderDirective to a functional directive.
+* Deprecate LazyEventEmitter and migrate uses to the StreamController model.
+* Additional styling cleanup to support `ng-deep`.
+* Reduce visibility of common directives/components for smaller code size and
    better performance.
- * Remove use of Compass in SASS files.
- * Remove uses of `getBool` in boolean typed inputs.
- * Remove unused alignment parameters.
- * Updates to use metadata inheritance.
- * Migrate away from comment-style generic syntax.
- * Migrate stylesheet combinators `/deep/` and `>>>` to `::ng-deep`.
- * Migrate away from use of angular's `@View`.
- * Remove unused library statements.
- * Refactor Angular annotations to inline versions.
- * Update documentation.
+* Remove use of Compass in SASS files.
+* Remove uses of `getBool` in boolean typed inputs.
+* Remove unused alignment parameters.
+* Updates to use metadata inheritance.
+* Migrate away from comment-style generic syntax.
+* Migrate stylesheet combinators `/deep/` and `>>>` to `::ng-deep`.
+* Migrate away from use of angular's `@View`.
+* Remove unused library statements.
+* Refactor Angular annotations to inline versions.
+* Update documentation.
 
 ### Known Issues
- * Warnings are present when building with dart2js. Specifically:
+
+* Warnings are present when building with dart2js. Specifically:
    _Method type variables are treated as `dynamic` in `as` expressions._
 
 ## 0.5.3+1
@@ -1504,70 +1692,70 @@ will be the basis for complete null safety migration.
 > corresponding .css files in a separate process. We are working on a solution
 > to include CSS generation from SASS files during the build process.
 
- * Add SASS files.
- * Rename .analysis_options -> analysis_options.yaml
+* Add SASS files.
+* Rename .analysis_options -> analysis_options.yaml
 
 ## 0.5.3
 
- * Add Material Tree component.
- * Material Dialog: Add `shouldShowScrollStrokes` option for displaying
+* Add Material Tree component.
+* Material Dialog: Add `shouldShowScrollStrokes` option for displaying
    stroke lines when the content is scrollable.
- * Material Dropdown Select: Avoid checking isSelected with deselectLabel.
- * Material Input: UpperBoundsValidator, and LowerBoundsValidator now use
+* Material Dropdown Select: Avoid checking isSelected with deselectLabel.
+* Material Input: UpperBoundsValidator, and LowerBoundsValidator now use
    `Comparable` instead of `num`.
- * Material Popup: Use the real viewport (aka window) size.
- * Scorecard: Add `ng-content` area for a description.
- * Adjust positioning algorithm to account for scrolling within elements.
- * Migrate use of LazyEventController to StreamController.
+* Material Popup: Use the real viewport (aka window) size.
+* Scorecard: Add `ng-content` area for a description.
+* Adjust positioning algorithm to account for scrolling within elements.
+* Migrate use of LazyEventController to StreamController.
 
 ## 0.5.2
 
- * Material Progress: Cleanup animations on destroy to prevent memory leaks.
- * Material Select:
-   * Support deselect item in Material dropdown select with single selection
+* Material Progress: Cleanup animations on destroy to prevent memory leaks.
+* Material Select:
+  * Support deselect item in Material dropdown select with single selection
      model.
-   * Unified template files (deleted material_select_dropdown_item.html).
-   * Add support for `Selectable` `SelectionOptions`.
-   * Create a `ControlValueAccessor`.
- * Add backspace and delete keys to `KeyboardHandlerMixin`.
- * Add `selectedValue` getter to `RadioGroupSingleSelectionModel`.
- * Add null check to `ObservableComposite`'s `register` method.
- * Add `totalEntitiesCountChange` getter to table selection models.
- * Add `isStandardMouseEvent` utility to test for clicks without modifier keys.
- * Add string selection sanitizing options.
- * Remove `NoopStream` in favor of `Stream.empty()` as provided by the SDK.
- * Migrate use of LazyEventController to StreamController.
- * Fix bug in lazy group creation that would cause multiple groups to be
+  * Unified template files (deleted material_select_dropdown_item.html).
+  * Add support for `Selectable` `SelectionOptions`.
+  * Create a `ControlValueAccessor`.
+* Add backspace and delete keys to `KeyboardHandlerMixin`.
+* Add `selectedValue` getter to `RadioGroupSingleSelectionModel`.
+* Add null check to `ObservableComposite`'s `register` method.
+* Add `totalEntitiesCountChange` getter to table selection models.
+* Add `isStandardMouseEvent` utility to test for clicks without modifier keys.
+* Add string selection sanitizing options.
+* Remove `NoopStream` in favor of `Stream.empty()` as provided by the SDK.
+* Migrate use of LazyEventController to StreamController.
+* Fix bug in lazy group creation that would cause multiple groups to be
    created.
- * Strong mode fixes.
+* Strong mode fixes.
 
 ## 0.5.1
 
- * Glyph: Add baseline attribute.
- * Material Expansionpanel:
-   * Allow programmatic `expand` and `collapse` requests even if the panel is
+* Glyph: Add baseline attribute.
+* Material Expansionpanel:
+  * Allow programmatic `expand` and `collapse` requests even if the panel is
      `disabled`.
-   * Change `preserveWhitespace` default to false.
-   * Add `enterAccepts` flag.
- * Material Input:
-   * Show counter regardless of focus.
-   * Add error message to `MaterialPercentInputDirective`.
- * Material List: Allow pointer events when disabled.
- * Material Popup: Fix positioning when `matchMinSourceWidth` is true.
- * Material Ripple: Show a centered ripple on keypress.
- * Material Select:
-   * Only display underline when border is also set.
-   * Add `useCheckMarks` to use check marks instead of checkboxes.
- * Material Tooltips: Resize to fit contents.
- * Material Yes/No Buttons: Add `enterAccepts` flag.
- * Deprecate LazyStreamController and migrate to StreamController.
- * Migrate use of LazyEventController to StreamController.
- * Documentation fixes.
- * Strong mode fixes.
+  * Change `preserveWhitespace` default to false.
+  * Add `enterAccepts` flag.
+* Material Input:
+  * Show counter regardless of focus.
+  * Add error message to `MaterialPercentInputDirective`.
+* Material List: Allow pointer events when disabled.
+* Material Popup: Fix positioning when `matchMinSourceWidth` is true.
+* Material Ripple: Show a centered ripple on keypress.
+* Material Select:
+  * Only display underline when border is also set.
+  * Add `useCheckMarks` to use check marks instead of checkboxes.
+* Material Tooltips: Resize to fit contents.
+* Material Yes/No Buttons: Add `enterAccepts` flag.
+* Deprecate LazyStreamController and migrate to StreamController.
+* Migrate use of LazyEventController to StreamController.
+* Documentation fixes.
+* Strong mode fixes.
 
 ## 0.5.0
 
- * Rename library to angular_components.
+* Rename library to angular_components.
 
 > All previous versions were published as the
 > [Pub Package](https://pub.dev/packages/angular2_components) named
@@ -1575,7 +1763,7 @@ will be the basis for complete null safety migration.
 
 ## 0.4.1-beta
 
- * Updated dependencies on `pkg/quiver` and `pkg/intl`.
+* Updated dependencies on `pkg/quiver` and `pkg/intl`.
 
 ## 0.4.1-alpha
 
@@ -1583,21 +1771,21 @@ This code is considered production quality, but depends on angular2:
 3.0.0-alpha+1. The alpha tag represents the evolving nature of the AngularDart
 API, not code quality (3.0.0-alpha+1 is used in production Google apps).
 
- * Add Dynamic Component.
- * Add Material Select.
- * Add core Material Design .scss files as a reference. Currently not used
+* Add Dynamic Component.
+* Add Material Select.
+* Add core Material Design .scss files as a reference. Currently not used
    during build.
- * Material Chip: Add option for icon on the left.
- * Material Expansionpanel: Add option to always display expansion icon.
- * Material Input:
-   * Add an optional errorRenderer that will allow clients to override/specify
+* Material Chip: Add option for icon on the left.
+* Material Expansionpanel: Add option to always display expansion icon.
+* Material Input:
+  * Add an optional errorRenderer that will allow clients to override/specify
      their own error messages.
-   * Add percent input directive.
- * Material Multiline Input: Fix 'hint' typo in inputs list.
- * Material Radio Group: Support deselecting all radio buttons for unmatched
+  * Add percent input directive.
+* Material Multiline Input: Fix 'hint' typo in inputs list.
+* Material Radio Group: Support deselecting all radio buttons for unmatched
    value.
- * Material Tooltip: Reduce delay.
- * i18l improvements.
+* Material Tooltip: Reduce delay.
+* i18l improvements.
 
 ## 0.4.0-alpha
 
@@ -1606,41 +1794,43 @@ This code is considered production quality, but depends on angular2:
 API, not code quality (3.0.0-alpha+1 is used in production Google apps).
 
 ### Breaking Changes
- * Update for generic syntax and `FutureOr` type introduced in Dart SDK 1.22.0.
- * Material Toggle: Remove the deprecated `color` theme input.
- * Material Button, Fab, Yes/No:
-   * Remove is-disabled and is-raised HTML classes used for styling.
+
+* Update for generic syntax and `FutureOr` type introduced in Dart SDK 1.22.0.
+* Material Toggle: Remove the deprecated `color` theme input.
+* Material Button, Fab, Yes/No:
+  * Remove is-disabled and is-raised HTML classes used for styling.
      Custom styles should now use `[disabled]` and `[raised]` instead of
      `.is-disabled` and `.is-raised` when targeting buttons.
-   * Remove z-index of 0.
+  * Remove z-index of 0.
 
 ### Other Changes
- * Focus: Fix AX_ARIA_08 a11y issue.
- * Glyph: Option to horizontally flip glyphs when the direction is RTL.
- * Material Chips: Use :host to remove need for wrapper div.
- * Material Expansionpanel: Fix panel overflow issues.
- * Material Input:
-   * Add new number accessors and validators.
-   * Add ability to override/specify error messages.
-   * Fix AX_TEXT_01 a11y issue.
- * Material List:
-   * Block pointer events for disabled list items.
-   * Remove duplicate mixin.
- * Material Popup: Disable animation delay when there is nothing to animate.
- * Material Radio: Fix styling issue, flex for IE11.
- * Material Tab Panel: Fix issue that prevents displaying tabs on
+
+* Focus: Fix AX_ARIA_08 a11y issue.
+* Glyph: Option to horizontally flip glyphs when the direction is RTL.
+* Material Chips: Use :host to remove need for wrapper div.
+* Material Expansionpanel: Fix panel overflow issues.
+* Material Input:
+  * Add new number accessors and validators.
+  * Add ability to override/specify error messages.
+  * Fix AX_TEXT_01 a11y issue.
+* Material List:
+  * Block pointer events for disabled list items.
+  * Remove duplicate mixin.
+* Material Popup: Disable animation delay when there is nothing to animate.
+* Material Radio: Fix styling issue, flex for IE11.
+* Material Tab Panel: Fix issue that prevents displaying tabs on
    initialization.
- * Material Yes/No Buttons: Add submit/cancel buttons.
- * Scorecard:
-   * Add support for RTL languages in scrollable scoreboards.
-   * Add support for themes.
-   * Prevent exceptions during width calculations when scorecard width is
+* Material Yes/No Buttons: Add submit/cancel buttons.
+* Scorecard:
+  * Add support for RTL languages in scrollable scoreboards.
+  * Add support for themes.
+  * Prevent exceptions during width calculations when scorecard width is
      `auto`.
- * Compute the ARIA roles only once per instance.
- * Fix dom update issues.
- * Add proper types to injected providers.
- * Add missing imports and remove unsupported Angular imports.
- * Strong mode fixes.
+* Compute the ARIA roles only once per instance.
+* Fix dom update issues.
+* Add proper types to injected providers.
+* Add missing imports and remove unsupported Angular imports.
+* Strong mode fixes.
 
 ## 0.3.1-alpha
 
@@ -1648,11 +1838,11 @@ This code is considered production quality, but depends on angular2:
 3.0.0-alpha. The alpha tag represents the evolving nature of the AngularDart
 API, not code quality (3.0.0-alpha is used in production Google apps).
 
- * Add Material List.
- * Material Expansionpanel: Add `autoDismissable` directive.
- * Material Progress: Handle changes to "indeterminate" state.
- * Scorecard: Add input to display vertically.
- * Update styles to meet Material UI spec.
+* Add Material List.
+* Material Expansionpanel: Add `autoDismissable` directive.
+* Material Progress: Handle changes to "indeterminate" state.
+* Scorecard: Add input to display vertically.
+* Update styles to meet Material UI spec.
 
 ## 0.3.0-alpha
 
@@ -1660,42 +1850,42 @@ This code is considered production quality, but depends on angular2:
 3.0.0-alpha. The alpha tag represents the evolving nature of the AngularDart
 API.
 
- * Add Material Tooltip.
- * Material Ripple:
-   * Add GPU acceleration.
-   * `rippleBindings` have been removed as they are no longer used.
- * Internal updates for compatibility with Angular 3.0.0-alpha.
- * Material Expansion Panel:
-   * Fix CSS rule that causes header text to turn gray on hover/focus.
-   * Support auto-focus on a content element when the material expansion panel
+* Add Material Tooltip.
+* Material Ripple:
+  * Add GPU acceleration.
+  * `rippleBindings` have been removed as they are no longer used.
+* Internal updates for compatibility with Angular 3.0.0-alpha.
+* Material Expansion Panel:
+  * Fix CSS rule that causes header text to turn gray on hover/focus.
+  * Support auto-focus on a content element when the material expansion panel
      expands.
-   * Fix Yes/No button ordering.
- * Material Input:
-   * Add a blur update value accessor.
-   * Add multiple attribute.
-   * Remove unused properties: rows and maxRows.
- * Material Input Multiline: Add auto grow in size.
- * Material Popup: Update change detection for OnPush.
- * Material Progress: Update to animate when main thread is blocked.
- * Material Radio: Adjust size to 24px.
- * Material Yes/No: Add toggle for yes button visibility.
- * Scorecard: Update change detection.
- * Fix flipped alignment positions when isRtl is used.
- * Fix popup event handling.
- * Remove 'uninitialized' as a default value.
- * Remove unused CSS rules.
- * Update styles to meet Material UI spec.
- * Bug fixes.
- * Strong Mode fixes.
+  * Fix Yes/No button ordering.
+* Material Input:
+  * Add a blur update value accessor.
+  * Add multiple attribute.
+  * Remove unused properties: rows and maxRows.
+* Material Input Multiline: Add auto grow in size.
+* Material Popup: Update change detection for OnPush.
+* Material Progress: Update to animate when main thread is blocked.
+* Material Radio: Adjust size to 24px.
+* Material Yes/No: Add toggle for yes button visibility.
+* Scorecard: Update change detection.
+* Fix flipped alignment positions when isRtl is used.
+* Fix popup event handling.
+* Remove 'uninitialized' as a default value.
+* Remove unused CSS rules.
+* Update styles to meet Material UI spec.
+* Bug fixes.
+* Strong Mode fixes.
 
 ## 0.2.2
 
- * Add Material Popup, a basic popup component.
- * Update Material Checkbox icon size.
- * Cleanup framework stabilizers since
+* Add Material Popup, a basic popup component.
+* Update Material Checkbox icon size.
+* Cleanup framework stabilizers since
    [issue #24843](https://github.com/dart-lang/sdk/issues/24843) in the Dart
    SDK has been resolved.
- * Remove unused files.
+* Remove unused files.
 
 ## 0.2.1
 

--- a/ngcomponents/lib/angular_components.dart
+++ b/ngcomponents/lib/angular_components.dart
@@ -4,8 +4,6 @@
 
 library angular_components;
 
-import 'package:ngforms/ngforms.dart';
-
 import 'app_layout/material_persistent_drawer.dart';
 import 'app_layout/material_stackable_drawer.dart';
 import 'app_layout/material_temporary_drawer.dart';

--- a/ngcomponents/lib/angular_components.dart
+++ b/ngcomponents/lib/angular_components.dart
@@ -4,6 +4,8 @@
 
 library angular_components;
 
+import 'package:ngforms/ngforms.dart';
+
 import 'app_layout/material_persistent_drawer.dart';
 import 'app_layout/material_stackable_drawer.dart';
 import 'app_layout/material_temporary_drawer.dart';

--- a/ngcomponents/lib/annotations/rtl_annotation.dart
+++ b/ngcomponents/lib/annotations/rtl_annotation.dart
@@ -4,7 +4,7 @@
 
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 
 /// Annotation bound to a boolean which is used to indicate that a complete
 /// web page is RTL.

--- a/ngcomponents/lib/app_layout/material_drawer_base.dart
+++ b/ngcomponents/lib/app_layout/material_drawer_base.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/content/deferred_content_aware.dart';
 
 // When deferred content should be removed. Needs to be longer than the longest

--- a/ngcomponents/lib/app_layout/material_persistent_drawer.dart
+++ b/ngcomponents/lib/app_layout/material_persistent_drawer.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/content/deferred_content_aware.dart';
 
 import 'material_drawer_base.dart';

--- a/ngcomponents/lib/app_layout/material_stackable_drawer.dart
+++ b/ngcomponents/lib/app_layout/material_stackable_drawer.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/app_layout/material_temporary_drawer.dart';
 import 'package:ngcomponents/content/deferred_content_aware.dart';
 

--- a/ngcomponents/lib/app_layout/material_temporary_drawer.dart
+++ b/ngcomponents/lib/app_layout/material_temporary_drawer.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/content/deferred_content_aware.dart';
 
 import 'material_drawer_base.dart';

--- a/ngcomponents/lib/auto_dismiss/auto_dismiss.dart
+++ b/ngcomponents/lib/auto_dismiss/auto_dismiss.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/utils/browser/events/events.dart';
 
 /// A directive that publishes a (dismiss) event when a focus, click or mouseup

--- a/ngcomponents/lib/button_decorator/button_decorator.dart
+++ b/ngcomponents/lib/button_decorator/button_decorator.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/focus/focus.dart';
 import 'package:ngcomponents/interfaces/has_disabled.dart';
 import 'package:ngcomponents/mixins/has_tab_index.dart';

--- a/ngcomponents/lib/content/deferred_content.dart
+++ b/ngcomponents/lib/content/deferred_content.dart
@@ -4,7 +4,7 @@
 
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/utils/disposer/disposer.dart';
 
 import 'deferred_content_aware.dart';

--- a/ngcomponents/lib/dynamic_component/dynamic_component.dart
+++ b/ngcomponents/lib/dynamic_component/dynamic_component.dart
@@ -4,8 +4,8 @@
 
 import 'dart:async';
 
-import 'package:angular/angular.dart';
-import 'package:angular/experimental.dart' show changeDetectionLink;
+import 'package:ngdart/angular.dart';
+import 'package:ngdart/experimental.dart' show changeDetectionLink;
 import 'package:ngcomponents/model/ui/has_renderer.dart';
 
 /// Dynamically renders another component, setting the [value] field on the

--- a/ngcomponents/lib/focus/focus.dart
+++ b/ngcomponents/lib/focus/focus.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html' show KeyCode, KeyboardEvent, Element, HtmlElement;
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:meta/meta.dart';
 import 'package:ngcomponents/laminate/components/modal/modal.dart';
 import 'package:ngcomponents/laminate/popup/popup.dart';

--- a/ngcomponents/lib/focus/focus_activable_item.dart
+++ b/ngcomponents/lib/focus/focus_activable_item.dart
@@ -4,7 +4,7 @@
 
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/focus/focus.dart';
 
 /// Used in conjunction with other components to allow tagging view or content

--- a/ngcomponents/lib/focus/focus_item.dart
+++ b/ngcomponents/lib/focus/focus_item.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html' show KeyboardEvent, HtmlElement;
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/focus/focus.dart';
 
 /// `FocusItemDirective`, used in conjunction with [FocusListDirective],

--- a/ngcomponents/lib/focus/focus_list.dart
+++ b/ngcomponents/lib/focus/focus_list.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/focus/focus.dart';
 import 'package:ngcomponents/utils/angular/properties/properties.dart';
 import 'package:ngcomponents/utils/disposer/disposer.dart';

--- a/ngcomponents/lib/focus/focus_trap.dart
+++ b/ngcomponents/lib/focus/focus_trap.dart
@@ -4,7 +4,7 @@
 
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/focus/focus.dart';
 import 'package:ngcomponents/utils/browser/dom_iterator/dom_iterator.dart';
 import 'package:ngcomponents/utils/disposer/disposer.dart';

--- a/ngcomponents/lib/focus/keyboard_only_focus_indicator.dart
+++ b/ngcomponents/lib/focus/keyboard_only_focus_indicator.dart
@@ -4,8 +4,8 @@
 
 import 'dart:html';
 
-import 'package:angular/angular.dart';
-import 'package:angular/src/meta.dart';
+import 'package:ngdart/angular.dart';
+import 'package:ngdart/src/meta.dart';
 import 'package:ngcomponents/utils/browser/dom_service/dom_service.dart';
 import 'package:meta/meta.dart';
 

--- a/ngcomponents/lib/glyph/glyph.dart
+++ b/ngcomponents/lib/glyph/glyph.dart
@@ -4,7 +4,7 @@
 
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/model/ui/icon.dart';
 
 /// Icons that should be horizontally flipped when the direction is RTL.

--- a/ngcomponents/lib/highlighted_text/highlighted_text.dart
+++ b/ngcomponents/lib/highlighted_text/highlighted_text.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/model/ui/highlighted_text_model.dart';
 
 /// A component that presents a list of [HighlightedTextSegment]s.

--- a/ngcomponents/lib/highlighted_text/highlighted_value.dart
+++ b/ngcomponents/lib/highlighted_text/highlighted_value.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/highlighted_text/highlighted_text.dart';
 import 'package:ngcomponents/model/ui/has_renderer.dart';
 import 'package:ngcomponents/model/ui/highlight_provider.dart';

--- a/ngcomponents/lib/laminate/components/modal/modal.dart
+++ b/ngcomponents/lib/laminate/components/modal/modal.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/content/deferred_content_aware.dart';
 import 'package:ngcomponents/src/laminate/components/modal/modal_controller_directive.dart';
 import 'package:ngcomponents/laminate/overlay/overlay.dart';

--- a/ngcomponents/lib/laminate/overlay/module.dart
+++ b/ngcomponents/lib/laminate/overlay/module.dart
@@ -4,7 +4,7 @@
 
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/laminate/overlay/constants.dart';
 import 'package:ngcomponents/src/laminate/overlay/overlay_service.dart';
 import 'package:ngcomponents/src/laminate/overlay/render/overlay_dom_render_service.dart';

--- a/ngcomponents/lib/laminate/overlay/zindexer.dart
+++ b/ngcomponents/lib/laminate/overlay/zindexer.dart
@@ -5,7 +5,7 @@
 @JS()
 library angular_components.css.acux.zindexer;
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:js/js.dart';
 
 @JS('acxZIndex')

--- a/ngcomponents/lib/laminate/popup/module.dart
+++ b/ngcomponents/lib/laminate/popup/module.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/laminate/enums/alignment.dart';
 import 'package:ngcomponents/laminate/overlay/module.dart';
 import 'package:ngcomponents/src/laminate/popup/dom_popup_source.dart';

--- a/ngcomponents/lib/laminate/portal/portal.dart
+++ b/ngcomponents/lib/laminate/portal/portal.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/utils/angular/imperative_view/imperative_view.dart';
 import 'package:ngcomponents/utils/disposer/disposer.dart';
 

--- a/ngcomponents/lib/laminate/ruler/dom_ruler.dart
+++ b/ngcomponents/lib/laminate/ruler/dom_ruler.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/src/laminate/ruler/ruler_interface.dart';
 import 'package:ngcomponents/utils/browser/dom_service/dom_service.dart';
 

--- a/ngcomponents/lib/laminate/ruler/module.dart
+++ b/ngcomponents/lib/laminate/ruler/module.dart
@@ -21,5 +21,5 @@ const rulerModule = Module(include: [
 const _rulerProviders = [
   ClassProvider(DomRuler),
   ClassProvider(ManagedZone, useClass: Angular2ManagedZone),
-  ClassProvider(NgRuler),
+  //ClassProvider(NgRuler),
 ];

--- a/ngcomponents/lib/laminate/ruler/module.dart
+++ b/ngcomponents/lib/laminate/ruler/module.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/laminate/ruler/dom_ruler.dart';
 import 'package:ngcomponents/laminate/ruler/ng_ruler.dart';
 import 'package:ngcomponents/utils/angular/managed_zone/angular_2.dart';

--- a/ngcomponents/lib/laminate/ruler/ng_ruler.dart
+++ b/ngcomponents/lib/laminate/ruler/ng_ruler.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:math';
 
-import 'package:angular/angular.dart' hide Visibility;
+import 'package:ngdart/angular.dart' hide Visibility;
 import 'package:ngcomponents/laminate/enums/position.dart';
 import 'package:ngcomponents/laminate/enums/visibility.dart';
 import 'package:ngcomponents/laminate/ruler/dom_ruler.dart';

--- a/ngcomponents/lib/material_button/material_button.dart
+++ b/ngcomponents/lib/material_button/material_button.dart
@@ -4,7 +4,7 @@
 
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/button_decorator/button_decorator.dart';
 import 'package:ngcomponents/interfaces/has_disabled.dart';
 import 'package:ngcomponents/material_ripple/material_ripple.dart';

--- a/ngcomponents/lib/material_button/material_button_base.dart
+++ b/ngcomponents/lib/material_button/material_button_base.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/button_decorator/button_decorator.dart';
 
 /// A base class from which to build buttons.

--- a/ngcomponents/lib/material_button/material_fab.dart
+++ b/ngcomponents/lib/material_button/material_fab.dart
@@ -4,7 +4,7 @@
 
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_ripple/material_ripple.dart';
 
 import 'material_button_base.dart';

--- a/ngcomponents/lib/material_checkbox/material_checkbox.dart
+++ b/ngcomponents/lib/material_checkbox/material_checkbox.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/focus/focus.dart';
 import 'package:ngcomponents/interfaces/has_disabled.dart';
 import 'package:ngcomponents/material_icon/material_icon.dart';
@@ -13,7 +13,7 @@ import 'package:ngcomponents/material_ripple/material_ripple.dart';
 import 'package:ngcomponents/model/ui/icon.dart';
 import 'package:ngcomponents/utils/browser/events/events.dart';
 import 'package:ngcomponents/utils/id_generator/id_generator.dart';
-import 'package:angular_forms/angular_forms.dart';
+import 'package:ngforms/ngforms.dart';
 import 'package:meta/meta.dart';
 
 const Icon uncheckedIcon = Icon('check_box_outline_blank');

--- a/ngcomponents/lib/material_chips/material_chip.dart
+++ b/ngcomponents/lib/material_chips/material_chip.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:intl/intl.dart';
 import 'package:ngcomponents/button_decorator/button_decorator.dart';
 import 'package:ngcomponents/focus/focus.dart';

--- a/ngcomponents/lib/material_chips/material_chips.dart
+++ b/ngcomponents/lib/material_chips/material_chips.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_chips/material_chip.dart';
 import 'package:ngcomponents/model/selection/selection_model.dart';
 import 'package:ngcomponents/model/ui/has_renderer.dart';

--- a/ngcomponents/lib/material_datepicker/date_input.dart
+++ b/ngcomponents/lib/material_datepicker/date_input.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:intl/intl.dart';
 import 'package:quiver/time.dart';
 import 'package:ngcomponents/material_input/material_input.dart';

--- a/ngcomponents/lib/material_datepicker/date_range_editor.dart
+++ b/ngcomponents/lib/material_datepicker/date_range_editor.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 import 'dart:html';
 import 'dart:math';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/button_decorator/button_decorator.dart';
 import 'package:ngcomponents/focus/focus.dart';
 import 'package:ngcomponents/focus/focus_item.dart';

--- a/ngcomponents/lib/material_datepicker/date_range_editor.dart
+++ b/ngcomponents/lib/material_datepicker/date_range_editor.dart
@@ -119,7 +119,7 @@ class DateRangeEditorComponent implements OnInit, AfterViewInit, Focusable {
   @Input()
   set useMenuForPresets(bool value) {
     _useMenuForPresets = value;
-    if (value && _presetsMenu == null) {
+    if (value) {
       _updateValidPresets();
     }
   }

--- a/ngcomponents/lib/material_datepicker/date_range_input.dart
+++ b/ngcomponents/lib/material_datepicker/date_range_input.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:intl/intl.dart';
 import 'package:ngcomponents/material_datepicker/calendar.dart';
 import 'package:ngcomponents/material_datepicker/date_input.dart';

--- a/ngcomponents/lib/material_datepicker/material_calendar_picker.dart
+++ b/ngcomponents/lib/material_datepicker/material_calendar_picker.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 import 'dart:html';
 import 'dart:js_util';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:collection/collection.dart' show IterableExtension;
 import 'package:intl/intl.dart';
 import 'package:quiver/time.dart';

--- a/ngcomponents/lib/material_datepicker/material_date_grid_base.dart
+++ b/ngcomponents/lib/material_datepicker/material_date_grid_base.dart
@@ -137,7 +137,7 @@ abstract class MaterialDateGridBase
     // Get the 1-indexed starting weekday for the current locale, and use that.
     startingWeekday = DateFormat().dateSymbols.FIRSTDAYOFWEEK + 1;
 
-    if (mode != null && mode.isNotEmpty) {
+    if (mode.isNotEmpty) {
       _mode = fuzzyParseEnum(CalendarSelectionMode.values, mode);
     }
   }

--- a/ngcomponents/lib/material_datepicker/material_date_grid_base.dart
+++ b/ngcomponents/lib/material_datepicker/material_date_grid_base.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 import 'dart:html';
 import 'dart:math';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:intl/intl.dart';
 import 'package:quiver/time.dart';
 import 'package:ngcomponents/material_datepicker/calendar.dart';

--- a/ngcomponents/lib/material_datepicker/material_date_range_picker.dart
+++ b/ngcomponents/lib/material_datepicker/material_date_range_picker.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 import 'dart:html';
 
 import 'package:ngdart/angular.dart';
-import 'package:ngdart/src/meta.dart';
 import 'package:ngcomponents/button_decorator/button_decorator.dart';
 import 'package:ngcomponents/content/deferred_content.dart';
 import 'package:ngcomponents/focus/focus.dart';

--- a/ngcomponents/lib/material_datepicker/material_date_range_picker.dart
+++ b/ngcomponents/lib/material_datepicker/material_date_range_picker.dart
@@ -5,8 +5,8 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
-import 'package:angular/src/meta.dart';
+import 'package:ngdart/angular.dart';
+import 'package:ngdart/src/meta.dart';
 import 'package:ngcomponents/button_decorator/button_decorator.dart';
 import 'package:ngcomponents/content/deferred_content.dart';
 import 'package:ngcomponents/focus/focus.dart';

--- a/ngcomponents/lib/material_datepicker/material_date_time_picker.dart
+++ b/ngcomponents/lib/material_datepicker/material_date_time_picker.dart
@@ -4,8 +4,8 @@
 
 import 'dart:async';
 
-import 'package:angular/angular.dart';
-import 'package:angular/src/meta.dart';
+import 'package:ngdart/angular.dart';
+import 'package:ngdart/src/meta.dart';
 import 'package:ngcomponents/interfaces/has_disabled.dart';
 import 'package:ngcomponents/material_datepicker/material_datepicker.dart';
 import 'package:ngcomponents/material_datepicker/material_time_picker.dart';

--- a/ngcomponents/lib/material_datepicker/material_datepicker.dart
+++ b/ngcomponents/lib/material_datepicker/material_datepicker.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/button_decorator/button_decorator.dart';
 import 'package:ngcomponents/content/deferred_content.dart';
 import 'package:ngcomponents/focus/focus.dart';

--- a/ngcomponents/lib/material_datepicker/material_month_picker.dart
+++ b/ngcomponents/lib/material_datepicker/material_month_picker.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:collection/collection.dart' show IterableExtension;
 import 'package:intl/intl.dart';
 import 'package:quiver/time.dart';

--- a/ngcomponents/lib/material_datepicker/material_time_picker.dart
+++ b/ngcomponents/lib/material_datepicker/material_time_picker.dart
@@ -397,9 +397,8 @@ class TimeSelectionOptions extends StringSelectionOptions<DateTime>
 
   @override
   SelectableOption getSelectable(DateTime item) {
-    return item is DateTime &&
-            ((_minTime != null && item.isBefore(_minTime!)) ||
-                (_maxTime != null && item.isAfter(_maxTime!)))
+    return ((_minTime != null && item.isBefore(_minTime!)) ||
+            (_maxTime != null && item.isAfter(_maxTime!)))
         ? SelectableOption.Disabled
         : SelectableOption.Selectable;
   }

--- a/ngcomponents/lib/material_datepicker/material_time_picker.dart
+++ b/ngcomponents/lib/material_datepicker/material_time_picker.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:intl/intl.dart';
 import 'package:quiver/time.dart';
 import 'package:ngcomponents/interfaces/has_disabled.dart';

--- a/ngcomponents/lib/material_datepicker/model.dart
+++ b/ngcomponents/lib/material_datepicker/model.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/di.dart';
+import 'package:ngdart/di.dart';
 import 'package:ngcomponents/model/observable/observable.dart';
 
 import 'comparison.dart';

--- a/ngcomponents/lib/material_datepicker/module.dart
+++ b/ngcomponents/lib/material_datepicker/module.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:quiver/time.dart';
 import 'package:ngcomponents/laminate/popup/module.dart';
 import 'package:ngcomponents/model/date/time_zone_aware_clock.dart';

--- a/ngcomponents/lib/material_datepicker/next_prev_buttons.dart
+++ b/ngcomponents/lib/material_datepicker/next_prev_buttons.dart
@@ -4,7 +4,7 @@
 
 import 'dart:html' show Event;
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:intl/intl.dart';
 import 'package:ngcomponents/src/material_datepicker/sequential.dart';
 import 'package:ngcomponents/material_icon/material_icon.dart';

--- a/ngcomponents/lib/material_datepicker/range.dart
+++ b/ngcomponents/lib/material_datepicker/range.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/di.dart';
+import 'package:ngdart/di.dart';
 import 'package:ngcomponents/material_datepicker/proto/date.pb.dart'
     as dateproto;
 import 'package:intl/intl.dart';

--- a/ngcomponents/lib/material_dialog/material_dialog.dart
+++ b/ngcomponents/lib/material_dialog/material_dialog.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/focus/focus_trap.dart';
 import 'package:ngcomponents/laminate/components/modal/modal.dart';
 import 'package:ngcomponents/model/a11y/keyboard_handler_mixin.dart';

--- a/ngcomponents/lib/material_expansionpanel/material_expansionpanel.dart
+++ b/ngcomponents/lib/material_expansionpanel/material_expansionpanel.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 import 'dart:html';
 import 'dart:math';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/button_decorator/button_decorator.dart';
 import 'package:ngcomponents/content/deferred_content.dart';
 import 'package:ngcomponents/content/deferred_content_aware.dart';

--- a/ngcomponents/lib/material_expansionpanel/material_expansionpanel_auto_dismiss.dart
+++ b/ngcomponents/lib/material_expansionpanel/material_expansionpanel_auto_dismiss.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/laminate/overlay/module.dart'
     show overlayContainerToken;
 import 'package:ngcomponents/material_expansionpanel/material_expansionpanel.dart';

--- a/ngcomponents/lib/material_expansionpanel/material_expansionpanel_set.dart
+++ b/ngcomponents/lib/material_expansionpanel/material_expansionpanel_set.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/model/action/async_action.dart';
 import 'package:ngcomponents/utils/disposer/disposer.dart';
 

--- a/ngcomponents/lib/material_icon/material_icon.dart
+++ b/ngcomponents/lib/material_icon/material_icon.dart
@@ -4,7 +4,7 @@
 
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/model/ui/icon.dart';
 
 /// Icons that should be horizontally flipped when the direction is RTL.

--- a/ngcomponents/lib/material_icon/material_icon_toggle.dart
+++ b/ngcomponents/lib/material_icon/material_icon_toggle.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 
 import 'material_icon.dart';
 

--- a/ngcomponents/lib/material_input/base_material_input.dart
+++ b/ngcomponents/lib/material_input/base_material_input.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/focus/focus.dart';
 import 'package:ngcomponents/forms/error_renderer.dart' show ErrorFn;
 import 'package:ngcomponents/interfaces/has_disabled.dart';
@@ -14,7 +14,7 @@ import 'package:ngcomponents/utils/angular/properties/properties.dart';
 import 'package:ngcomponents/utils/angular/reference/reference.dart';
 import 'package:ngcomponents/utils/disposer/disposer.dart';
 import 'package:ngcomponents/utils/id_generator/id_generator.dart';
-import 'package:angular_forms/angular_forms.dart';
+import 'package:ngforms/ngforms.dart';
 import 'package:intl/intl.dart';
 import 'package:quiver/strings.dart' show isEmpty, isNotEmpty;
 

--- a/ngcomponents/lib/material_input/deferred_validator.dart
+++ b/ngcomponents/lib/material_input/deferred_validator.dart
@@ -2,8 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
-import 'package:angular_forms/angular_forms.dart';
+import 'package:ngdart/angular.dart';
+import 'package:ngforms/ngforms.dart';
 
 typedef ValidatorFn = Map<String, dynamic>? Function(AbstractControl c);
 

--- a/ngcomponents/lib/material_input/input_wrapper.dart
+++ b/ngcomponents/lib/material_input/input_wrapper.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/interfaces/has_disabled.dart';
 
 import 'base_material_input.dart';

--- a/ngcomponents/lib/material_input/material_auto_suggest_input.dart
+++ b/ngcomponents/lib/material_input/material_auto_suggest_input.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html' as html;
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:collection/collection.dart';
 import 'package:ngcomponents/button_decorator/button_decorator.dart';
 import 'package:ngcomponents/content/deferred_content.dart';
@@ -42,7 +42,7 @@ import 'package:ngcomponents/stop_propagation/stop_propagation.dart';
 import 'package:ngcomponents/utils/angular/properties/properties.dart';
 import 'package:ngcomponents/utils/async/async.dart';
 import 'package:ngcomponents/utils/id_generator/id_generator.dart';
-import 'package:angular_forms/angular_forms.dart';
+import 'package:ngforms/ngforms.dart';
 import 'package:meta/meta.dart';
 
 import 'material_input.dart';

--- a/ngcomponents/lib/material_input/material_auto_suggest_input.dart
+++ b/ngcomponents/lib/material_input/material_auto_suggest_input.dart
@@ -835,7 +835,7 @@ class MaterialAutoSuggestInputComponent<T> extends MaterialSelectBase<T>
 
   @override
   void writeValue(newValue) {
-    _setInputText(newValue as String);
+    _setInputText(newValue as String?);
   }
 
   @override

--- a/ngcomponents/lib/material_input/material_input.dart
+++ b/ngcomponents/lib/material_input/material_input.dart
@@ -2,8 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
-import 'package:angular_forms/angular_forms.dart';
+import 'package:ngdart/angular.dart';
+import 'package:ngforms/ngforms.dart';
 import 'package:ngcomponents/focus/focus.dart';
 import 'package:ngcomponents/interfaces/has_disabled.dart';
 import 'package:ngcomponents/material_icon/material_icon.dart';
@@ -14,7 +14,7 @@ import 'deferred_validator.dart';
 import 'material_input_default_value_accessor.dart';
 import 'material_input_multiline.dart';
 
-export 'package:angular_forms/angular_forms.dart' show NgModel;
+export 'package:ngforms/ngforms.dart' show NgModel;
 
 export 'base_material_input.dart' show ValidityCheck, CharacterCounter;
 export 'material_input_default_value_accessor.dart';

--- a/ngcomponents/lib/material_input/material_input_auto_select.dart
+++ b/ngcomponents/lib/material_input/material_input_auto_select.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/utils/disposer/disposer.dart';
 
 import 'base_material_input.dart';

--- a/ngcomponents/lib/material_input/material_input_default_value_accessor.dart
+++ b/ngcomponents/lib/material_input/material_input_default_value_accessor.dart
@@ -4,8 +4,8 @@
 
 import 'dart:async';
 
-import 'package:angular/angular.dart';
-import 'package:angular_forms/angular_forms.dart';
+import 'package:ngdart/angular.dart';
+import 'package:ngforms/ngforms.dart';
 import 'package:meta/meta.dart';
 import 'package:ngcomponents/utils/disposer/disposer.dart';
 

--- a/ngcomponents/lib/material_input/material_input_multiline.dart
+++ b/ngcomponents/lib/material_input/material_input_multiline.dart
@@ -5,13 +5,13 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/focus/focus.dart';
 import 'package:ngcomponents/interfaces/has_disabled.dart';
 import 'package:ngcomponents/utils/angular/properties/properties.dart';
 import 'package:ngcomponents/utils/angular/reference/reference.dart';
 import 'package:ngcomponents/utils/browser/dom_service/angular_2.dart';
-import 'package:angular_forms/angular_forms.dart';
+import 'package:ngforms/ngforms.dart';
 
 import 'base_material_input.dart';
 import 'deferred_validator.dart';

--- a/ngcomponents/lib/material_input/material_number_accessor.dart
+++ b/ngcomponents/lib/material_input/material_number_accessor.dart
@@ -4,9 +4,9 @@
 
 import 'dart:async';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/utils/angular/properties/properties.dart';
-import 'package:angular_forms/angular_forms.dart';
+import 'package:ngforms/ngforms.dart';
 import 'package:fixnum/fixnum.dart';
 import 'package:intl/intl.dart';
 import 'package:quiver/strings.dart';

--- a/ngcomponents/lib/material_input/material_number_validators.dart
+++ b/ngcomponents/lib/material_input/material_number_validators.dart
@@ -2,8 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
-import 'package:angular_forms/angular_forms.dart';
+import 'package:ngdart/angular.dart';
+import 'package:ngforms/ngforms.dart';
 import 'package:intl/intl.dart';
 
 import 'material_input_error_keys.dart';

--- a/ngcomponents/lib/material_input/material_percent_directive.dart
+++ b/ngcomponents/lib/material_input/material_percent_directive.dart
@@ -4,7 +4,7 @@
 
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:intl/intl.dart';
 import 'package:ngcomponents/material_input/material_input.dart';
 import 'package:ngcomponents/material_input/material_input_error_keys.dart';

--- a/ngcomponents/lib/material_list/material_list.dart
+++ b/ngcomponents/lib/material_list/material_list.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/model/ui/accepts_width.dart';
 import 'package:ngcomponents/utils/angular/properties/properties.dart';
 

--- a/ngcomponents/lib/material_list/material_list_item.dart
+++ b/ngcomponents/lib/material_list/material_list_item.dart
@@ -4,7 +4,7 @@
 
 import 'dart:html' as dom;
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/button_decorator/button_decorator.dart';
 import 'package:ngcomponents/interfaces/has_disabled.dart';
 import 'package:ngcomponents/mixins/material_dropdown_base.dart';

--- a/ngcomponents/lib/material_menu/affix/base_affix.dart
+++ b/ngcomponents/lib/material_menu/affix/base_affix.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/interfaces/has_disabled.dart';
 import 'package:ngcomponents/model/menu/menu_item_affix.dart';
 import 'package:ngcomponents/model/ui/has_renderer.dart';

--- a/ngcomponents/lib/material_menu/affix/caption_affix.dart
+++ b/ngcomponents/lib/material_menu/affix/caption_affix.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_menu/affix/base_affix.dart';
 import 'package:ngcomponents/material_menu/affix/caption_affix_model.dart';
 

--- a/ngcomponents/lib/material_menu/affix/caption_affix_model.dart
+++ b/ngcomponents/lib/material_menu/affix/caption_affix_model.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_menu/affix/base_affix.dart';
 import 'package:ngcomponents/material_menu/affix/caption_affix.template.dart'
     as ng;

--- a/ngcomponents/lib/material_menu/affix/icon_affix.dart
+++ b/ngcomponents/lib/material_menu/affix/icon_affix.dart
@@ -4,7 +4,7 @@
 
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/button_decorator/button_decorator.dart';
 import 'package:ngcomponents/material_icon/material_icon.dart';
 import 'package:ngcomponents/material_menu/affix/base_affix.dart';

--- a/ngcomponents/lib/material_menu/affix/icon_affix_model.dart
+++ b/ngcomponents/lib/material_menu/affix/icon_affix_model.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_menu/affix/base_affix.dart';
 import 'package:ngcomponents/material_menu/affix/icon_affix.template.dart'
     as ng;

--- a/ngcomponents/lib/material_menu/common/menu_root.dart
+++ b/ngcomponents/lib/material_menu/common/menu_root.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/mixins/material_dropdown_base.dart';
 
 /// A directive providing a [MenuRoot] through the injected [DropdownHandle].

--- a/ngcomponents/lib/material_menu/dropdown_menu.dart
+++ b/ngcomponents/lib/material_menu/dropdown_menu.dart
@@ -4,7 +4,7 @@
 
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/focus/focus.dart';
 import 'package:ngcomponents/interfaces/has_disabled.dart';
 import 'package:ngcomponents/material_menu/menu_popup.dart';

--- a/ngcomponents/lib/material_menu/material_fab_menu.dart
+++ b/ngcomponents/lib/material_menu/material_fab_menu.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/content/deferred_content.dart';
 import 'package:ngcomponents/focus/focus.dart';
 import 'package:ngcomponents/focus/focus_trap.dart';

--- a/ngcomponents/lib/material_menu/material_menu.dart
+++ b/ngcomponents/lib/material_menu/material_menu.dart
@@ -4,7 +4,7 @@
 
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/focus/focus.dart';
 import 'package:ngcomponents/interfaces/has_disabled.dart';
 import 'package:ngcomponents/material_button/material_button.dart';

--- a/ngcomponents/lib/material_menu/menu_item_affix_list.dart
+++ b/ngcomponents/lib/material_menu/menu_item_affix_list.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/dynamic_component/dynamic_component.dart';
 import 'package:ngcomponents/interfaces/has_disabled.dart';
 import 'package:ngcomponents/material_menu/affix/base_affix.dart';

--- a/ngcomponents/lib/material_menu/menu_item_groups.dart
+++ b/ngcomponents/lib/material_menu/menu_item_groups.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/button_decorator/button_decorator.dart';
 import 'package:ngcomponents/content/deferred_content.dart';
 import 'package:ngcomponents/focus/focus.dart';

--- a/ngcomponents/lib/material_menu/menu_popup.dart
+++ b/ngcomponents/lib/material_menu/menu_popup.dart
@@ -4,7 +4,7 @@
 
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/content/deferred_content.dart';
 import 'package:ngcomponents/focus/focus.dart';
 import 'package:ngcomponents/focus/focus_trap.dart';

--- a/ngcomponents/lib/material_menu/menu_popup_wrapper.dart
+++ b/ngcomponents/lib/material_menu/menu_popup_wrapper.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/angular_components.dart';
 import 'package:ngcomponents/model/menu/menu.dart';
 import 'package:ngcomponents/model/observable/observable.dart';

--- a/ngcomponents/lib/material_popup/material_popup.dart
+++ b/ngcomponents/lib/material_popup/material_popup.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 import 'dart:html';
 import 'dart:math';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:meta/meta.dart';
 import 'package:ngcomponents/content/deferred_content_aware.dart';
 import 'package:ngcomponents/focus/focus_interface.dart';

--- a/ngcomponents/lib/material_progress/material_progress.dart
+++ b/ngcomponents/lib/material_progress/material_progress.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:intl/intl.dart';
 import 'package:ngcomponents/utils/browser/feature_detector/feature_detector.dart'
     show supportsAnimationApi;

--- a/ngcomponents/lib/material_radio/material_radio.dart
+++ b/ngcomponents/lib/material_radio/material_radio.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/focus/focus.dart';
 import 'package:ngcomponents/interfaces/has_disabled.dart';
 import 'package:ngcomponents/material_icon/material_icon.dart';
@@ -14,7 +14,7 @@ import 'package:ngcomponents/material_ripple/material_ripple.dart';
 import 'package:ngcomponents/model/ui/icon.dart';
 import 'package:ngcomponents/utils/browser/events/events.dart';
 import 'package:ngcomponents/utils/disposer/disposer.dart';
-import 'package:angular_forms/angular_forms.dart';
+import 'package:ngforms/ngforms.dart';
 import 'package:meta/meta.dart';
 
 const Icon uncheckedIcon = Icon('radio_button_unchecked');

--- a/ngcomponents/lib/material_radio/material_radio_group.dart
+++ b/ngcomponents/lib/material_radio/material_radio_group.dart
@@ -4,8 +4,8 @@
 
 import 'dart:async';
 
-import 'package:angular/angular.dart';
-import 'package:angular_forms/angular_forms.dart';
+import 'package:ngdart/angular.dart';
+import 'package:ngforms/ngforms.dart';
 import 'package:ngcomponents/focus/focus.dart';
 import 'package:ngcomponents/material_radio/material_radio.dart';
 import 'package:ngcomponents/model/selection/selection_model.dart';

--- a/ngcomponents/lib/material_ripple/material_ripple.dart
+++ b/ngcomponents/lib/material_ripple/material_ripple.dart
@@ -5,7 +5,7 @@
 import 'dart:html';
 import 'dart:math';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/utils/browser/events/events.dart';
 import 'package:ngcomponents/utils/browser/feature_detector/feature_detector.dart'
     show supportsAnimationApi;

--- a/ngcomponents/lib/material_select/display_name.dart
+++ b/ngcomponents/lib/material_select/display_name.dart
@@ -4,7 +4,7 @@
 
 //import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/model/ui/display_name.dart';
 import 'package:ngcomponents/model/ui/has_renderer.dart';
 

--- a/ngcomponents/lib/material_select/dropdown_button.dart
+++ b/ngcomponents/lib/material_select/dropdown_button.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/button_decorator/button_decorator.dart';
 import 'package:ngcomponents/focus/focus_interface.dart';
 import 'package:ngcomponents/focus/keyboard_only_focus_indicator.dart';

--- a/ngcomponents/lib/material_select/material_dropdown_select.dart
+++ b/ngcomponents/lib/material_select/material_dropdown_select.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/annotations/rtl_annotation.dart';
 import 'package:ngcomponents/content/deferred_content.dart';
 import 'package:ngcomponents/content/deferred_content_aware.dart';

--- a/ngcomponents/lib/material_select/material_dropdown_select_accessor.dart
+++ b/ngcomponents/lib/material_select/material_dropdown_select_accessor.dart
@@ -4,8 +4,8 @@
 
 import 'dart:async';
 
-import 'package:angular/angular.dart';
-import 'package:angular_forms/angular_forms.dart';
+import 'package:ngdart/angular.dart';
+import 'package:ngforms/ngforms.dart';
 import 'package:meta/meta.dart';
 import 'package:ngcomponents/model/selection/selection_model.dart';
 

--- a/ngcomponents/lib/material_select/material_select.dart
+++ b/ngcomponents/lib/material_select/material_select.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/focus/focus_item.dart';
 import 'package:ngcomponents/focus/focus_list.dart';
 import 'package:ngcomponents/interfaces/has_disabled.dart';

--- a/ngcomponents/lib/material_select/material_select_dropdown_item.dart
+++ b/ngcomponents/lib/material_select/material_select_dropdown_item.dart
@@ -4,7 +4,7 @@
 
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/dynamic_component/dynamic_component.dart';
 import 'package:ngcomponents/material_checkbox/material_checkbox.dart';
 import 'package:ngcomponents/material_icon/material_icon.dart';

--- a/ngcomponents/lib/material_select/material_select_item.dart
+++ b/ngcomponents/lib/material_select/material_select_item.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/button_decorator/button_decorator.dart';
 import 'package:ngcomponents/dynamic_component/dynamic_component.dart';
 import 'package:ngcomponents/interfaces/has_disabled.dart';

--- a/ngcomponents/lib/material_select/material_select_searchbox.dart
+++ b/ngcomponents/lib/material_select/material_select_searchbox.dart
@@ -4,13 +4,14 @@
 
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/focus/focus_interface.dart';
 import 'package:ngcomponents/material_input/material_input.dart';
 import 'package:ngcomponents/mixins/focusable_mixin.dart';
 import 'package:ngcomponents/model/selection/select.dart';
 import 'package:ngcomponents/utils/async/async.dart';
 import 'package:ngcomponents/utils/browser/events/events.dart';
+import 'package:ngforms/ngforms.dart';
 
 /// A simple component that maps an input box to the [Filterable] interface.
 ///

--- a/ngcomponents/lib/material_slider/material_slider.dart
+++ b/ngcomponents/lib/material_slider/material_slider.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 import 'dart:html';
 import 'dart:math' as math;
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:intl/intl.dart';
 import 'package:quiver/check.dart';
 import 'package:ngcomponents/interfaces/has_disabled.dart';

--- a/ngcomponents/lib/material_spinner/material_spinner.dart
+++ b/ngcomponents/lib/material_spinner/material_spinner.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 
 /// A circular spinner for an indeterminate amount of time following the
 /// Material Spec for Progress & Activity.

--- a/ngcomponents/lib/material_stepper/material_step.dart
+++ b/ngcomponents/lib/material_stepper/material_step.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/laminate/portal/portal.dart';
 import 'package:ngcomponents/model/action/async_action.dart';
 

--- a/ngcomponents/lib/material_stepper/material_stepper.dart
+++ b/ngcomponents/lib/material_stepper/material_stepper.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:intl/intl.dart';
 import 'package:ngcomponents/button_decorator/button_decorator.dart';
 import 'package:ngcomponents/laminate/portal/portal.dart';

--- a/ngcomponents/lib/material_tab/fixed_material_tab_strip.dart
+++ b/ngcomponents/lib/material_tab/fixed_material_tab_strip.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/annotations/rtl_annotation.dart';
 import 'package:ngcomponents/focus/focus_item.dart';
 import 'package:ngcomponents/focus/focus_list.dart';

--- a/ngcomponents/lib/material_tab/material_tab.dart
+++ b/ngcomponents/lib/material_tab/material_tab.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/content/deferred_content_aware.dart';
 import 'package:ngcomponents/focus/focus.dart';
 import 'package:ngcomponents/utils/id_generator/id_generator.dart';

--- a/ngcomponents/lib/material_tab/material_tab_panel.dart
+++ b/ngcomponents/lib/material_tab/material_tab_panel.dart
@@ -83,7 +83,7 @@ class MaterialTabPanelComponent implements AfterContentInit {
   }
 
   void _initTabs() {
-    _tabLabels = _tabs.map((t) => t.label).toList().cast<String>();
+    _tabLabels = _tabs.map((t) => t.label).whereType<String>().toList();
     _tabIds = _tabs.map((t) => t.tabId).toList();
 
     // Setting the active tab needs to happen in the next turn as it is changing

--- a/ngcomponents/lib/material_tab/material_tab_panel.dart
+++ b/ngcomponents/lib/material_tab/material_tab_panel.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_tab/fixed_material_tab_strip.dart';
 import 'package:ngcomponents/material_tab/material_tab.dart';
 import 'package:ngcomponents/material_tab/tab_change_event.dart';

--- a/ngcomponents/lib/material_tab/tab_button.dart
+++ b/ngcomponents/lib/material_tab/tab_button.dart
@@ -4,7 +4,7 @@
 
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_button/material_button_base.dart';
 import 'package:ngcomponents/material_ripple/material_ripple.dart';
 import 'package:ngcomponents/material_tab/tab_mixin.dart';

--- a/ngcomponents/lib/material_tab/tab_mixin.dart
+++ b/ngcomponents/lib/material_tab/tab_mixin.dart
@@ -4,7 +4,7 @@
 
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 
 /// A mixin for use by tab button component and tab dropdown menu component.
 abstract class TabMixin {

--- a/ngcomponents/lib/material_toggle/material_toggle.dart
+++ b/ngcomponents/lib/material_toggle/material_toggle.dart
@@ -5,8 +5,8 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
-import 'package:angular_forms/angular_forms.dart';
+import 'package:ngdart/angular.dart';
+import 'package:ngforms/ngforms.dart';
 import 'package:meta/meta.dart';
 import 'package:ngcomponents/interfaces/has_disabled.dart';
 import 'package:ngcomponents/utils/browser/events/events.dart';

--- a/ngcomponents/lib/material_tooltip/module.dart
+++ b/ngcomponents/lib/material_tooltip/module.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/src/material_tooltip/tooltip_controller.dart';
 import 'package:ngcomponents/utils/disposer/disposer.dart';
 

--- a/ngcomponents/lib/material_yes_no_buttons/material_yes_no_buttons.dart
+++ b/ngcomponents/lib/material_yes_no_buttons/material_yes_no_buttons.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:intl/intl.dart';
 import 'package:ngcomponents/focus/focus.dart';
 import 'package:ngcomponents/interfaces/has_disabled.dart';

--- a/ngcomponents/lib/mixins/button_wrapper.dart
+++ b/ngcomponents/lib/mixins/button_wrapper.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/interfaces/has_disabled.dart';
 import 'package:ngcomponents/model/ui/icon.dart';
 

--- a/ngcomponents/lib/mixins/focusable_mixin.dart
+++ b/ngcomponents/lib/mixins/focusable_mixin.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/focus/focus.dart';
 
 /// Assistant for focusing an element.

--- a/ngcomponents/lib/mixins/has_tab_index.dart
+++ b/ngcomponents/lib/mixins/has_tab_index.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:quiver/strings.dart' show isBlank;
 
 /// Provides computation of tabindex for components which actively maintain

--- a/ngcomponents/lib/mixins/highlight_assistant_mixin.dart
+++ b/ngcomponents/lib/mixins/highlight_assistant_mixin.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/highlighted_text/highlighted_value.dart';
 import 'package:ngcomponents/highlighted_text/highlighted_value.template.dart'
     as highlight;

--- a/ngcomponents/lib/mixins/material_dropdown_base.dart
+++ b/ngcomponents/lib/mixins/material_dropdown_base.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/content/deferred_content_aware.dart';
 import 'package:ngcomponents/laminate/enums/alignment.dart';
 import 'package:ngcomponents/laminate/popup/popup.dart';

--- a/ngcomponents/lib/mixins/selection_input_adapter.dart
+++ b/ngcomponents/lib/mixins/selection_input_adapter.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:angular/di.dart';
+import 'package:ngdart/di.dart';
 import 'package:meta/meta.dart';
 import 'package:ngcomponents/model/selection/selection_container.dart';
 import 'package:ngcomponents/model/selection/selection_model.dart';

--- a/ngcomponents/lib/mixins/track_layout_changes.dart
+++ b/ngcomponents/lib/mixins/track_layout_changes.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 
 /// Mixin for trackLayoutChanges property pass through to material popup to
 /// avoid duplicate code in multiple components.

--- a/ngcomponents/lib/model/a11y/active_item_directive.dart
+++ b/ngcomponents/lib/model/a11y/active_item_directive.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html' as dom;
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:js/js_util.dart' as js_util;
 import 'package:ngcomponents/laminate/components/modal/modal.dart';
 import 'package:ngcomponents/laminate/popup/popup.dart';

--- a/ngcomponents/lib/model/a11y/focus_indicator_controller.dart
+++ b/ngcomponents/lib/model/a11y/focus_indicator_controller.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/di.dart';
+import 'package:ngdart/di.dart';
 
 const focusIndicatorProviders = [
   FactoryProvider(

--- a/ngcomponents/lib/model/date/time_zone_aware_clock.dart
+++ b/ngcomponents/lib/model/date/time_zone_aware_clock.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:angular/di.dart';
+import 'package:ngdart/di.dart';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:quiver/time.dart';

--- a/ngcomponents/lib/model/selection/string_selection_options.dart
+++ b/ngcomponents/lib/model/selection/string_selection_options.dart
@@ -114,7 +114,7 @@ class StringSelectionOptions<T> extends SelectionOptions<T>
   @override
   DisposableFuture<bool> filter(Object query, {int? limit = -1}) {
     _currentLimit = limit! < 1 ? UNLIMITED : limit;
-    _currentQuery = query as String;
+    _currentQuery = query as String? ?? '';
     refilter();
     return DisposableFuture.fromValue(true);
   }

--- a/ngcomponents/lib/model/ui/has_factory.dart
+++ b/ngcomponents/lib/model/ui/has_factory.dart
@@ -5,7 +5,7 @@
 // This file is separate from has_renderer.dart so it doesn't add the angular
 // dependency and transitively 'dart:html', which doesn't work in a simple
 // dart_test.
-import 'package:angular/angular.dart' show ComponentFactory;
+import 'package:ngdart/angular.dart' show ComponentFactory;
 
 import 'has_renderer.dart';
 

--- a/ngcomponents/lib/model/ui/template_support.dart
+++ b/ngcomponents/lib/model/ui/template_support.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 
 /// Function for use by NgFor for optionGroup to avoid recreating the
 /// DOM for the optionGroup.

--- a/ngcomponents/lib/reorder_list/reorder_list.dart
+++ b/ngcomponents/lib/reorder_list/reorder_list.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 import 'dart:html';
 import 'dart:math';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:quiver/iterables.dart' show range;
 import 'package:ngcomponents/reorder_list/reorder_events.dart';
 import 'package:ngcomponents/utils/disposer/disposer.dart';

--- a/ngcomponents/lib/scorecard/scoreboard.dart
+++ b/ngcomponents/lib/scorecard/scoreboard.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:intl/intl.dart';
 import 'package:ngcomponents/material_button/material_button.dart';
 import 'package:ngcomponents/material_icon/material_icon.dart';

--- a/ngcomponents/lib/scorecard/scorecard.dart
+++ b/ngcomponents/lib/scorecard/scorecard.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/focus/keyboard_only_focus_indicator.dart';
 import 'package:ngcomponents/material_icon/material_icon.dart';
 import 'package:ngcomponents/material_ripple/material_ripple.dart';

--- a/ngcomponents/lib/scorecard/scorecard_bar.dart
+++ b/ngcomponents/lib/scorecard/scorecard_bar.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/annotations/rtl_annotation.dart';
 import 'package:ngcomponents/utils/browser/dom_service/angular_2.dart';
 import 'package:ngcomponents/utils/disposer/disposer.dart';

--- a/ngcomponents/lib/simple_html/simple_html.dart
+++ b/ngcomponents/lib/simple_html/simple_html.dart
@@ -6,7 +6,7 @@ import 'dart:async' show Stream, StreamController;
 import 'dart:html'
     show Element, NodeValidator, NodeValidatorBuilder, UIEvent, UriPolicy;
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:logging/logging.dart' show Logger;
 import 'package:quiver/check.dart';
 import 'package:ngcomponents/utils/angular/properties/properties.dart';

--- a/ngcomponents/lib/src/laminate/components/modal/modal_controller_directive.dart
+++ b/ngcomponents/lib/src/laminate/components/modal/modal_controller_directive.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/laminate/overlay/overlay.dart';
 import 'package:ngcomponents/laminate/portal/portal.dart';
 

--- a/ngcomponents/lib/src/laminate/overlay/overlay_service.dart
+++ b/ngcomponents/lib/src/laminate/overlay/overlay_service.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/src/laminate/overlay/overlay_ref.dart';
 import 'package:ngcomponents/src/laminate/overlay/overlay_state.dart';
 import 'package:ngcomponents/src/laminate/overlay/render/overlay_dom_render_service.dart';

--- a/ngcomponents/lib/src/laminate/overlay/render/overlay_dom_render_service.dart
+++ b/ngcomponents/lib/src/laminate/overlay/render/overlay_dom_render_service.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart' hide Visibility;
+import 'package:ngdart/angular.dart' hide Visibility;
 import 'package:ngcomponents/laminate/enums/visibility.dart';
 import 'package:ngcomponents/src/laminate/overlay/overlay_state.dart';
 import 'package:ngcomponents/src/laminate/overlay/render/overlay_style_config.dart';

--- a/ngcomponents/lib/src/laminate/overlay/render/overlay_style_config.dart
+++ b/ngcomponents/lib/src/laminate/overlay/render/overlay_style_config.dart
@@ -4,7 +4,7 @@
 
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 
 /// Adds CSS to the `document.head` location in order to use overlays.
 ///

--- a/ngcomponents/lib/src/laminate/popup/dom_popup_source.dart
+++ b/ngcomponents/lib/src/laminate/popup/dom_popup_source.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/annotations/rtl_annotation.dart';
 import 'package:ngcomponents/laminate/enums/alignment.dart';
 import 'package:ngcomponents/laminate/ruler/dom_ruler.dart';

--- a/ngcomponents/lib/src/laminate/popup/popup_hierarchy.dart
+++ b/ngcomponents/lib/src/laminate/popup/popup_hierarchy.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/laminate/overlay/constants.dart';
 import 'package:ngcomponents/utils/browser/events/events.dart' as events;
 

--- a/ngcomponents/lib/src/laminate/popup/popup_interface.dart
+++ b/ngcomponents/lib/src/laminate/popup/popup_interface.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/angular_components.dart';
 
 /// A reusable interface for something that is or delegates to [PopupComponent].

--- a/ngcomponents/lib/src/laminate/popup/popup_position_mixin.dart
+++ b/ngcomponents/lib/src/laminate/popup/popup_position_mixin.dart
@@ -4,7 +4,7 @@
 
 import 'dart:math';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/laminate/enums/alignment.dart';
 import 'package:ngcomponents/src/laminate/popup/popup_size_provider.dart';
 

--- a/ngcomponents/lib/src/laminate/popup/popup_size_provider_directive.dart
+++ b/ngcomponents/lib/src/laminate/popup/popup_size_provider_directive.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/src/laminate/popup/popup_size_provider.dart';
 
 /// Directive to provide maximum and minimum sizes to a popup from html.

--- a/ngcomponents/lib/src/laminate/popup/popup_source_directive.dart
+++ b/ngcomponents/lib/src/laminate/popup/popup_source_directive.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/focus/focus_interface.dart';
 import 'package:ngcomponents/laminate/enums/alignment.dart';
 import 'package:ngcomponents/src/laminate/popup/dom_popup_source.dart';

--- a/ngcomponents/lib/src/material_datepicker/comparison_range_editor.dart
+++ b/ngcomponents/lib/src/material_datepicker/comparison_range_editor.dart
@@ -4,7 +4,7 @@
 
 import 'dart:core';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:intl/intl.dart';
 import 'package:ngcomponents/material_datepicker/comparison_option.dart';
 import 'package:ngcomponents/material_datepicker/date_range_input.dart';

--- a/ngcomponents/lib/src/material_tooltip/icon_tooltip.dart
+++ b/ngcomponents/lib/src/material_tooltip/icon_tooltip.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:intl/intl.dart';
 import 'package:ngcomponents/content/deferred_content_aware.dart';
 import 'package:ngcomponents/focus/keyboard_only_focus_indicator.dart';

--- a/ngcomponents/lib/src/material_tooltip/ink_tooltip.dart
+++ b/ngcomponents/lib/src/material_tooltip/ink_tooltip.dart
@@ -4,7 +4,7 @@
 
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/content/deferred_content.dart';
 import 'package:ngcomponents/laminate/enums/alignment.dart';
 import 'package:ngcomponents/laminate/popup/popup.dart' show PopupSource;

--- a/ngcomponents/lib/src/material_tooltip/paper_tooltip.dart
+++ b/ngcomponents/lib/src/material_tooltip/paper_tooltip.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/content/deferred_content.dart';
 import 'package:ngcomponents/content/deferred_content_aware.dart';
 import 'package:ngcomponents/focus/focus.dart';

--- a/ngcomponents/lib/src/material_tooltip/tooltip.dart
+++ b/ngcomponents/lib/src/material_tooltip/tooltip.dart
@@ -4,7 +4,7 @@
 
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/laminate/enums/alignment.dart';
 import 'package:ngcomponents/laminate/popup/popup.dart'
     show DomPopupSourceFactory;

--- a/ngcomponents/lib/src/material_tooltip/tooltip_controller.dart
+++ b/ngcomponents/lib/src/material_tooltip/tooltip_controller.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 
 /// Lightweight interface for Tooltip components to implement so they can be
 /// controlled by a [TooltipController].

--- a/ngcomponents/lib/src/material_tooltip/tooltip_source.dart
+++ b/ngcomponents/lib/src/material_tooltip/tooltip_source.dart
@@ -4,7 +4,7 @@
 
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:intl/intl.dart';
 import 'package:ngcomponents/laminate/popup/popup.dart'
     show DomPopupSourceFactory, PopupSourceDirective, PopupRef;

--- a/ngcomponents/lib/src/material_tooltip/tooltip_target.dart
+++ b/ngcomponents/lib/src/material_tooltip/tooltip_target.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/laminate/overlay/constants.dart';
 import 'package:ngcomponents/laminate/popup/popup.dart';
 import 'package:ngcomponents/model/action/delayed_action.dart';

--- a/ngcomponents/lib/src/material_tree/group/material_tree_group.dart
+++ b/ngcomponents/lib/src/material_tree/group/material_tree_group.dart
@@ -4,7 +4,7 @@
 
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:intl/intl.dart';
 import 'package:ngcomponents/button_decorator/button_decorator.dart';
 import 'package:ngcomponents/dynamic_component/dynamic_component.dart';

--- a/ngcomponents/lib/src/material_tree/group/material_tree_group_flat.dart
+++ b/ngcomponents/lib/src/material_tree/group/material_tree_group_flat.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/button_decorator/button_decorator.dart';
 import 'package:ngcomponents/dynamic_component/dynamic_component.dart';
 import 'package:ngcomponents/material_checkbox/material_checkbox.dart';

--- a/ngcomponents/lib/src/material_tree/material_tree_dropdown.dart
+++ b/ngcomponents/lib/src/material_tree/material_tree_dropdown.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/content/deferred_content.dart';
 import 'package:ngcomponents/focus/focus.dart';
 import 'package:ngcomponents/focus/keyboard_only_focus_indicator.dart';

--- a/ngcomponents/lib/src/material_tree/material_tree_filter.dart
+++ b/ngcomponents/lib/src/material_tree/material_tree_filter.dart
@@ -7,7 +7,7 @@ library angular_components.material_tree.src.material_tree_filter;
 
 import 'dart:async';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/material_input/material_input.dart';
 import 'package:ngcomponents/src/material_tree/material_tree_root.dart';
 import 'package:ngcomponents/model/selection/select.dart';

--- a/ngcomponents/lib/src/material_tree/material_tree_impl.dart
+++ b/ngcomponents/lib/src/material_tree/material_tree_impl.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/model/selection/select.dart';
 import 'package:ngcomponents/model/selection/selection_container.dart';
 import 'package:ngcomponents/model/selection/selection_model.dart';

--- a/ngcomponents/lib/src/material_tree/material_tree_node.dart
+++ b/ngcomponents/lib/src/material_tree/material_tree_node.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/src/material_tree/material_tree_expand_state.dart';
 import 'package:ngcomponents/src/material_tree/material_tree_root.dart';
 import 'package:ngcomponents/model/selection/select.dart';

--- a/ngcomponents/lib/src/utils/angular/scroll_host/gestures.dart
+++ b/ngcomponents/lib/src/utils/angular/scroll_host/gestures.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 import 'dart:html';
 import 'dart:math' as math;
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:quiver/time.dart';
 import 'package:ngcomponents/src/utils/angular/scroll_host/scroll_host_event_impl.dart';
 import 'package:ngcomponents/src/utils/angular/scroll_host/scroll_host_interface.dart';

--- a/ngcomponents/lib/src/utils/angular/scroll_host/pan_controller_impl.dart
+++ b/ngcomponents/lib/src/utils/angular/scroll_host/pan_controller_impl.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/utils/angular/scroll_host/interface.dart';
 import 'package:ngcomponents/utils/async/async.dart';
 import 'package:ngcomponents/utils/browser/dom_service/dom_service.dart';

--- a/ngcomponents/lib/src/utils/angular/scroll_host/scroll_host_base.dart
+++ b/ngcomponents/lib/src/utils/angular/scroll_host/scroll_host_base.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 import 'dart:html';
 import 'dart:math' show max;
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:js/js.dart' as js;
 import 'package:logging/logging.dart' show Logger;
 import 'package:ngcomponents/src/utils/angular/scroll_host/gestures.dart';

--- a/ngcomponents/lib/stop_propagation/stop_propagation.dart
+++ b/ngcomponents/lib/stop_propagation/stop_propagation.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/utils/browser/events/events.dart';
 
 /// A directive that prevents button trigger events from propagating.

--- a/ngcomponents/lib/theme/dark_theme.dart
+++ b/ngcomponents/lib/theme/dark_theme.dart
@@ -4,7 +4,7 @@
 
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/theme/module.dart';
 
 /// The class applied to elements which have been themed, iff the dark theme is

--- a/ngcomponents/lib/theme/module.dart
+++ b/ngcomponents/lib/theme/module.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 
 /// Sets dark mode for components which support it.
 const darkThemeToken = OpaqueToken<bool>('acxDarkTheme');

--- a/ngcomponents/lib/utils/angular/id/id.dart
+++ b/ngcomponents/lib/utils/angular/id/id.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/utils/id_generator/id_generator.dart';
 
 /// A directive that assign a unique id to its element.

--- a/ngcomponents/lib/utils/angular/imperative_view/imperative_view.dart
+++ b/ngcomponents/lib/utils/angular/imperative_view/imperative_view.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/utils/browser/dom_service/dom_service.dart';
 import 'package:ngcomponents/utils/disposer/disposer.dart';
 

--- a/ngcomponents/lib/utils/angular/managed_zone/angular_2.dart
+++ b/ngcomponents/lib/utils/angular/managed_zone/angular_2.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/src/utils/angular/managed_zone/managed_zone.dart';
 
 export 'package:ngcomponents/src/utils/angular/managed_zone/managed_zone.dart';

--- a/ngcomponents/lib/utils/angular/reference/reference.dart
+++ b/ngcomponents/lib/utils/angular/reference/reference.dart
@@ -4,7 +4,7 @@
 
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 
 // TODO(google): Remove this once use of '#' in a template is either
 // consistent, or has a way to declare specifically what you want - e.g. the

--- a/ngcomponents/lib/utils/angular/scroll_host/angular_2.dart
+++ b/ngcomponents/lib/utils/angular/scroll_host/angular_2.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/src/utils/angular/scroll_host/scroll_host_base.dart';
 import 'package:ngcomponents/utils/angular/scroll_host/interface.dart';
 import 'package:ngcomponents/utils/browser/dom_service/angular_2.dart';

--- a/ngcomponents/lib/utils/browser/dom_service/angular_2.dart
+++ b/ngcomponents/lib/utils/browser/dom_service/angular_2.dart
@@ -4,8 +4,8 @@
 
 import 'dart:html';
 
-import 'package:angular/angular.dart';
-import 'package:angular/experimental.dart';
+import 'package:ngdart/angular.dart';
+import 'package:ngdart/experimental.dart';
 import 'package:ngcomponents/utils/browser/dom_service/dom_service.dart';
 import 'package:ngcomponents/utils/browser/dom_service/dom_service_webdriver_testability.dart';
 import 'package:ngcomponents/utils/disposer/disposer.dart';

--- a/ngcomponents/lib/utils/browser/dom_service/dom_service.dart
+++ b/ngcomponents/lib/utils/browser/dom_service/dom_service.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 import 'dart:html';
 import 'dart:math' show max, min;
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:ngcomponents/utils/async/async.dart';
 import 'package:ngcomponents/utils/disposer/disposable_callback.dart';
 // TODO(google): Consolidate this with RenderSync /Angular.

--- a/ngcomponents/lib/utils/browser/events/events.dart
+++ b/ngcomponents/lib/utils/browser/events/events.dart
@@ -8,7 +8,7 @@ library events;
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:js/js.dart';
 import 'package:js/js_util.dart' as js_util;
 import 'package:ngcomponents/utils/browser/feature_detector/feature_detector.dart';

--- a/ngcomponents/lib/utils/browser/window/module.dart
+++ b/ngcomponents/lib/utils/browser/window/module.dart
@@ -4,7 +4,7 @@
 
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 
 // These are necessary because 'const' functions don't yet exist within Dart.
 

--- a/ngcomponents/lib/utils/browser/window/new_window_opener.dart
+++ b/ngcomponents/lib/utils/browser/window/new_window_opener.dart
@@ -4,7 +4,7 @@
 
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 
 /// Utility class to allow opening a URL in a new window.
 @Injectable()

--- a/ngcomponents/lib/utils/keyboard/global_escape_directive.dart
+++ b/ngcomponents/lib/utils/keyboard/global_escape_directive.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 
 /// Directive to listen to the escape key globally.
 ///

--- a/ngcomponents/lib/utils/showhide/showhide.dart
+++ b/ngcomponents/lib/utils/showhide/showhide.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:angular/angular.dart';
+import 'package:ngdart/angular.dart';
 import 'package:async/async.dart' show StreamQueue;
 import 'package:ngcomponents/utils/browser/dom_service/angular_2.dart';
 

--- a/ngcomponents/null_coverage.dart
+++ b/ngcomponents/null_coverage.dart
@@ -47,6 +47,6 @@ Future<void> main(List<String> args) async {
   }
 
   need_migrate.forEach((element) {
-    print('- [ ] ' + p.relative(element, from: 'lib'));
+    print('- [ ] ${p.relative(element, from: 'lib')}');
   });
 }

--- a/ngcomponents/pubspec.yaml
+++ b/ngcomponents/pubspec.yaml
@@ -4,11 +4,11 @@ description: Angular material components for AngularDart maintained by the commu
 repository: https://github.com/angulardart-community/angular_components
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  angular: ^7.0.1
-  angular_forms: ^4.0.0
+  ngdart: ^7.1.0
+  ngforms: ^4.1.0
   async: ^2.1.0
   build: ^2.1.1
   build_config: ^1.0.0

--- a/ngcomponents/pubspec.yaml
+++ b/ngcomponents/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ngcomponents
-version: 2.0.0-dev.2
+version: 3.0.0-dev.1
 description: Angular material components for AngularDart maintained by the community. 
 repository: https://github.com/angulardart-community/angular_components
 
@@ -29,3 +29,4 @@ dev_dependencies:
   lints: ^2.0.0
   path: ^1.6.1
   test: ^1.0.0
+  build_runner: ^2.1.4

--- a/ngcomponents/test/ensure_proto_build_test.dart
+++ b/ngcomponents/test/ensure_proto_build_test.dart
@@ -27,7 +27,7 @@ void main() {
     // Use the version of protoc on the $PATH if available.
     var result = Process.runSync('which', ['protoc']);
     if (result.exitCode == 0) {
-      protocPath = (result.stdout as String).trim();
+      protocPath = (result.stdout as String?)?.trim() ?? '';
     }
 
     final datepickerProtoPath = '${currentDir}/lib/material_datepicker/proto';
@@ -72,7 +72,7 @@ String _runProc(String proc, List<String> args) {
   var result = Process.runSync(proc, args);
   if (result.exitCode != 0) {
     throw ProcessException(
-        proc, args, result.stderr as String, result.exitCode);
+        proc, args, result.stderr as String? ?? '', result.exitCode);
   }
-  return (result.stdout as String).trim();
+  return (result.stdout as String?)?.trim() ?? '';
 }


### PR DESCRIPTION
1. Migrated the codebase to use `ngdart`
2. Required Dart SDK <= 2.17.0
3. Fixed null safety issues flagged by SDK 2.17 & 2.18
4. Replaced deprecated `ClassElement` with `InterfaceElement`
5. The `angular_examples_component` can successfully build and run with SDK 2.17 & 2.18
